### PR TITLE
Add settings hardening tests (#2, #4) and update roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,14 +19,14 @@
 - [x] RSVPOverlay state machine tests (play/pause/nav/wpm clamping) — extracted to `rsvp/state-machine.js`
 - [ ] Content script decision tree tests (selection priority, Readability fallback, error paths)
 - [x] Settings persistence round-trip test (write → new instance → verify)
-- [ ] Settings init with pre-populated out-of-range UserDefaults test
+- [x] Settings init with pre-populated out-of-range UserDefaults test
 - [x] Guard `splitWordAtFocus` against empty string input
 - [ ] Guard `calculateDelay` against empty string input
 - [x] Settings test isolation — inject ephemeral UserDefaults to prevent test pollution
-- [ ] `saveSettingsToAppGroup` — track saved field count, log warning when zero fields match types
-- [ ] `syncSettingsFromNative` — surface sync failure to user (e.g., store lastSyncStatus flag)
+- [x] `saveSettingsToAppGroup` — track saved field count, log warning when zero fields match types
+- [x] `syncSettingsFromNative` — surface sync failure to user (e.g., store lastSyncStatus flag)
 - [x] Selection read failure — show toast when selection is ignored due to API error
-- [ ] App Group unavailable — surface visible warning in SwiftUI app when settings won't sync
+- [x] App Group unavailable — surface visible warning in SwiftUI app when settings won't sync
 - [ ] Full regression test infrastructure — `make send`-style command router, scripted assertions for all overlay states, keyboard shortcuts, WPM changes, theme switching, multi-platform coverage
 
 ## v2 — Enhanced Navigation

--- a/SpeedReader/Shared/SettingsKeys.swift
+++ b/SpeedReader/Shared/SettingsKeys.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.log
 
 /// Font options for the RSVP reader.
 enum ReaderFont: String, CaseIterable, Identifiable {
@@ -69,5 +70,45 @@ enum SettingsKeys {
     /// Clamp an integer to a range.
     static func clamp(_ value: Int, min: Int, max: Int) -> Int {
         Swift.max(min, Swift.min(max, value))
+    }
+
+    /// Saves settings to the given UserDefaults store with type checking and clamping.
+    /// Returns the number of fields that matched expected types.
+    @discardableResult
+    static func saveSettings(_ settings: [String: Any], to defaults: UserDefaults) -> Int {
+        var savedCount = 0
+
+        if let wpm = settings["wpm"] as? Int {
+            defaults.set(clamp(wpm, min: wpmMin, max: wpmMax), forKey: SettingsKeys.wpm)
+            savedCount += 1
+        }
+        if let font = settings["font"] as? String,
+           ReaderFont(rawValue: font) != nil {
+            defaults.set(font, forKey: SettingsKeys.font)
+            savedCount += 1
+        }
+        if let theme = settings["theme"] as? String,
+           ReaderTheme(rawValue: theme) != nil {
+            defaults.set(theme, forKey: SettingsKeys.theme)
+            savedCount += 1
+        }
+        if let fontSize = settings["fontSize"] as? Int {
+            defaults.set(clamp(fontSize, min: fontSizeMin, max: fontSizeMax), forKey: SettingsKeys.fontSize)
+            savedCount += 1
+        }
+        if let punctuationPause = settings["punctuationPause"] as? Bool {
+            defaults.set(punctuationPause, forKey: SettingsKeys.punctuationPause)
+            savedCount += 1
+        }
+
+        if savedCount == 0 && !settings.isEmpty {
+            os_log(
+                .error,
+                "[SpeedReader] saveSettings: 0/%d keys matched types",
+                settings.count
+            )
+        }
+
+        return savedCount
     }
 }

--- a/SpeedReader/SpeedReaderExtension/SafariWebExtensionHandler.swift
+++ b/SpeedReader/SpeedReaderExtension/SafariWebExtensionHandler.swift
@@ -69,43 +69,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             os_log(.error, "[SpeedReader] App Group not available for saving settings")
             return 0
         }
-
-        var savedCount = 0
-
-        if let wpm = settings["wpm"] as? Int {
-            defaults.set(SettingsKeys.clamp(wpm, min: SettingsKeys.wpmMin, max: SettingsKeys.wpmMax),
-                         forKey: SettingsKeys.wpm)
-            savedCount += 1
-        }
-        if let font = settings["font"] as? String,
-           ReaderFont(rawValue: font) != nil {
-            defaults.set(font, forKey: SettingsKeys.font)
-            savedCount += 1
-        }
-        if let theme = settings["theme"] as? String,
-           ReaderTheme(rawValue: theme) != nil {
-            defaults.set(theme, forKey: SettingsKeys.theme)
-            savedCount += 1
-        }
-        if let fontSize = settings["fontSize"] as? Int {
-            defaults.set(SettingsKeys.clamp(fontSize, min: SettingsKeys.fontSizeMin, max: SettingsKeys.fontSizeMax),
-                         forKey: SettingsKeys.fontSize)
-            savedCount += 1
-        }
-        if let punctuationPause = settings["punctuationPause"] as? Bool {
-            defaults.set(punctuationPause, forKey: SettingsKeys.punctuationPause)
-            savedCount += 1
-        }
-
-        if savedCount == 0 && !settings.isEmpty {
-            os_log(
-                .error,
-                "[SpeedReader] saveSettingsToAppGroup: 0/%d keys matched types",
-                settings.count
-            )
-        }
-
-        return savedCount
+        return SettingsKeys.saveSettings(settings, to: defaults)
     }
 
     private func defaultSettings() -> [String: Any] {

--- a/SpeedReader/SpeedReaderTests/SettingsTests.swift
+++ b/SpeedReader/SpeedReaderTests/SettingsTests.swift
@@ -76,6 +76,156 @@ final class SettingsTests: XCTestCase {
         XCTAssertTrue(settings.appGroupAvailable, "Injected defaults should report App Group as available")
     }
 
+    // MARK: - Init with pre-populated out-of-range UserDefaults
+
+    func testInitClampsWPMBelowMinimum() {
+        let store = makeDefaults()
+        store.set(50, forKey: SettingsKeys.wpm)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.wpm, SettingsKeys.wpmMin)
+    }
+
+    func testInitClampsWPMAboveMaximum() {
+        let store = makeDefaults()
+        store.set(999, forKey: SettingsKeys.wpm)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.wpm, SettingsKeys.wpmMax)
+    }
+
+    func testInitClampsFontSizeBelowMinimum() {
+        let store = makeDefaults()
+        store.set(10, forKey: SettingsKeys.fontSize)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.fontSize, SettingsKeys.fontSizeMin)
+    }
+
+    func testInitClampsFontSizeAboveMaximum() {
+        let store = makeDefaults()
+        store.set(200, forKey: SettingsKeys.fontSize)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.fontSize, SettingsKeys.fontSizeMax)
+    }
+
+    func testInitFallsBackForInvalidFontRawValue() {
+        let store = makeDefaults()
+        store.set("comic-sans", forKey: SettingsKeys.font)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.font, SettingsKeys.Defaults.font)
+    }
+
+    func testInitFallsBackForInvalidThemeRawValue() {
+        let store = makeDefaults()
+        store.set("neon-pink", forKey: SettingsKeys.theme)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.theme, SettingsKeys.Defaults.theme)
+    }
+
+    func testInitFallsBackWhenWPMStoredAsWrongType() {
+        let store = makeDefaults()
+        store.set("not-a-number", forKey: SettingsKeys.wpm)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.wpm, SettingsKeys.Defaults.wpm)
+    }
+
+    func testInitFallsBackWhenFontSizeStoredAsWrongType() {
+        let store = makeDefaults()
+        store.set("big", forKey: SettingsKeys.fontSize)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.fontSize, SettingsKeys.Defaults.fontSize)
+    }
+
+    func testInitFallsBackWhenPunctuationPauseStoredAsWrongType() {
+        let store = makeDefaults()
+        store.set("yes", forKey: SettingsKeys.punctuationPause)
+        let settings = ReaderSettings(defaults: store)
+        XCTAssertEqual(settings.punctuationPause, SettingsKeys.Defaults.punctuationPause)
+    }
+
+    // MARK: - saveSettings type checking and clamping
+
+    func testSaveSettingsWithValidPayloadSavesAllFields() {
+        let store = makeDefaults()
+        let payload: [String: Any] = [
+            "wpm": 300,
+            "font": "opendyslexic",
+            "theme": "dark",
+            "fontSize": 36,
+            "punctuationPause": false,
+        ]
+        let count = SettingsKeys.saveSettings(payload, to: store)
+        XCTAssertEqual(count, 5)
+        XCTAssertEqual(store.integer(forKey: SettingsKeys.wpm), 300)
+        XCTAssertEqual(store.string(forKey: SettingsKeys.font), "opendyslexic")
+        XCTAssertEqual(store.string(forKey: SettingsKeys.theme), "dark")
+        XCTAssertEqual(store.integer(forKey: SettingsKeys.fontSize), 36)
+        XCTAssertFalse(store.bool(forKey: SettingsKeys.punctuationPause))
+    }
+
+    func testSaveSettingsWithAllWrongTypesSavesZero() {
+        let store = makeDefaults()
+        let payload: [String: Any] = [
+            "wpm": "fast",
+            "font": 42,
+            "theme": true,
+            "fontSize": "big",
+            "punctuationPause": 1,
+        ]
+        let count = SettingsKeys.saveSettings(payload, to: store)
+        XCTAssertEqual(count, 0)
+    }
+
+    func testSaveSettingsWithPartialMismatchSavesOnlyValid() {
+        let store = makeDefaults()
+        let payload: [String: Any] = [
+            "wpm": 200,           // valid
+            "font": 42,           // wrong type
+            "theme": "dark",      // valid
+            "fontSize": "big",    // wrong type
+            "punctuationPause": true,  // valid
+        ]
+        let count = SettingsKeys.saveSettings(payload, to: store)
+        XCTAssertEqual(count, 3)
+        XCTAssertEqual(store.integer(forKey: SettingsKeys.wpm), 200)
+        XCTAssertEqual(store.string(forKey: SettingsKeys.theme), "dark")
+        XCTAssertTrue(store.bool(forKey: SettingsKeys.punctuationPause))
+    }
+
+    func testSaveSettingsRejectsInvalidFontRawValue() {
+        let store = makeDefaults()
+        let payload: [String: Any] = ["font": "comic-sans"]
+        let count = SettingsKeys.saveSettings(payload, to: store)
+        XCTAssertEqual(count, 0)
+    }
+
+    func testSaveSettingsRejectsInvalidThemeRawValue() {
+        let store = makeDefaults()
+        let payload: [String: Any] = ["theme": "neon-pink"]
+        let count = SettingsKeys.saveSettings(payload, to: store)
+        XCTAssertEqual(count, 0)
+    }
+
+    func testSaveSettingsClampsWPMToValidRange() {
+        let store = makeDefaults()
+        let count = SettingsKeys.saveSettings(["wpm": 9999], to: store)
+        XCTAssertEqual(count, 1)
+        XCTAssertEqual(store.integer(forKey: SettingsKeys.wpm), SettingsKeys.wpmMax)
+    }
+
+    func testSaveSettingsClampsFontSizeToValidRange() {
+        let store = makeDefaults()
+        let count = SettingsKeys.saveSettings(["fontSize": 1], to: store)
+        XCTAssertEqual(count, 1)
+        XCTAssertEqual(store.integer(forKey: SettingsKeys.fontSize), SettingsKeys.fontSizeMin)
+    }
+
+    func testSaveSettingsWithEmptyPayloadReturnsZero() {
+        let store = makeDefaults()
+        let count = SettingsKeys.saveSettings([:], to: store)
+        XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - Persistence round-trip
+
     func testSettingsPersistAcrossInstances() {
         let store = makeDefaults()
         let first = ReaderSettings(defaults: store)


### PR DESCRIPTION
## Summary
- Add 9 tests for `ReaderSettings` init with pre-populated out-of-range UserDefaults — verifies WPM/fontSize clamping, invalid font/theme rawValues, and wrong-type fallbacks
- Extract `saveSettingsToAppGroup` save logic to `SettingsKeys.saveSettings(_:to:)` for dependency-injection testability (same pattern as `ReaderSettings.init(defaults:)`)
- Add 8 tests for `saveSettings` — valid payload, all-wrong-types, partial mismatches, invalid enum values, range clamping, empty payload
- Update ROADMAP: mark hardening tasks #2, #4, #5, #6 as complete (#5 and #6 were done in previous PR)

## Test plan
- [x] All 29 Swift tests pass (`xcodebuild test -destination 'platform=macOS'`)
- [x] All 40 JS tests pass (`npx vitest run --reporter=verbose`)
- [ ] Manual: verify settings sync between companion app and extension still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)