### PR TITLE
Add configurable chunk size (1, 2, or 3 words per flash)

### DIFF
--- a/SpeedReader/Shared/SettingsKeys.swift
+++ b/SpeedReader/Shared/SettingsKeys.swift
@@ -65,6 +65,7 @@ enum SettingsKeys {
     static let fontSize = "sr_fontSize"
     static let punctuationPause = "sr_punctuationPause"
     static let alignment = "sr_alignment"
+    static let chunkSize = "sr_chunkSize"
 
     /// Default values — typed enum cases prevent drift from raw values.
     enum Defaults {
@@ -74,6 +75,7 @@ enum SettingsKeys {
         static let fontSize = 42
         static let punctuationPause = true
         static let alignment: ReaderAlignment = .orpAligned
+        static let chunkSize = 1
     }
 
     /// WPM bounds
@@ -89,6 +91,10 @@ enum SettingsKeys {
 
     /// Font size range for sliders
     static let fontSizeRange = Double(fontSizeMin)...Double(fontSizeMax)
+
+    /// Chunk size bounds
+    static let chunkSizeMin = 1
+    static let chunkSizeMax = 3
 
     /// Clamp an integer to a range.
     static func clamp(_ value: Int, min: Int, max: Int) -> Int {
@@ -126,6 +132,10 @@ enum SettingsKeys {
         if let alignment = settings["alignment"] as? String,
            ReaderAlignment(rawValue: alignment) != nil {
             defaults.set(alignment, forKey: SettingsKeys.alignment)
+            savedCount += 1
+        }
+        if let chunkSize = settings["chunkSize"] as? Int {
+            defaults.set(clamp(chunkSize, min: chunkSizeMin, max: chunkSizeMax), forKey: SettingsKeys.chunkSize)
             savedCount += 1
         }
 

--- a/SpeedReader/SpeedReader/Models/Settings.swift
+++ b/SpeedReader/SpeedReader/Models/Settings.swift
@@ -16,6 +16,7 @@ final class ReaderSettings {
     var fontSize: Int = SettingsKeys.Defaults.fontSize
     var punctuationPause: Bool = SettingsKeys.Defaults.punctuationPause
     var alignment: ReaderAlignment = SettingsKeys.Defaults.alignment
+    var chunkSize: Int = SettingsKeys.Defaults.chunkSize
 
     init(defaults: UserDefaults? = nil) {
         let store: UserDefaults
@@ -77,6 +78,12 @@ final class ReaderSettings {
         defaults.set(alignment.rawValue, forKey: SettingsKeys.alignment)
     }
 
+    /// Sets chunk size, clamped to valid range, and persists to UserDefaults.
+    func setChunkSize(_ value: Int) {
+        chunkSize = SettingsKeys.clamp(value, min: SettingsKeys.chunkSizeMin, max: SettingsKeys.chunkSizeMax)
+        defaults.set(chunkSize, forKey: SettingsKeys.chunkSize)
+    }
+
     private func loadFromDefaults(_ store: UserDefaults) {
         let loadedWpm = store.object(forKey: SettingsKeys.wpm) as? Int
             ?? SettingsKeys.Defaults.wpm
@@ -102,5 +109,11 @@ final class ReaderSettings {
         let alignmentRaw = store.string(forKey: SettingsKeys.alignment)
             ?? SettingsKeys.Defaults.alignment.rawValue
         alignment = ReaderAlignment(rawValue: alignmentRaw) ?? SettingsKeys.Defaults.alignment
+
+        let loadedChunkSize = store.object(forKey: SettingsKeys.chunkSize) as? Int
+            ?? SettingsKeys.Defaults.chunkSize
+        chunkSize = SettingsKeys.clamp(
+            loadedChunkSize, min: SettingsKeys.chunkSizeMin, max: SettingsKeys.chunkSizeMax
+        )
     }
 }

--- a/SpeedReader/SpeedReader/Views/SettingsView.swift
+++ b/SpeedReader/SpeedReader/Views/SettingsView.swift
@@ -81,7 +81,7 @@ private struct RSVPPreview: View {
     var body: some View {
         Group {
             if chunkSize > 1 {
-                Text("the quick brown")
+                Text(chunkSize == 2 ? "the quick" : "the quick brown")
                     .foregroundColor(textColor)
                     .font(font.font(size: CGFloat(fontSize)))
                     .lineLimit(1)

--- a/SpeedReader/SpeedReader/Views/SettingsView.swift
+++ b/SpeedReader/SpeedReader/Views/SettingsView.swift
@@ -34,6 +34,7 @@ private struct RSVPPreview: View {
     let fontSize: Int
     let theme: ReaderTheme
     let alignment: ReaderAlignment
+    let chunkSize: Int
 
     private let word = "knowledge"
 
@@ -79,11 +80,20 @@ private struct RSVPPreview: View {
 
     var body: some View {
         Group {
-            wordText
-                .font(font.font(size: CGFloat(fontSize)))
-                .lineLimit(1)
-                .minimumScaleFactor(0.3)
-                .frame(maxWidth: .infinity)
+            if chunkSize > 1 {
+                Text("the quick brown")
+                    .foregroundColor(textColor)
+                    .font(font.font(size: CGFloat(fontSize)))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.3)
+                    .frame(maxWidth: .infinity)
+            } else {
+                wordText
+                    .font(font.font(size: CGFloat(fontSize)))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.3)
+                    .frame(maxWidth: .infinity)
+            }
         }
         .padding(.vertical, 24)
         .background(backgroundColor)
@@ -140,6 +150,16 @@ struct SettingsView: View {
                     get: { settings.punctuationPause },
                     set: { settings.setPunctuationPause($0) }
                 ))
+
+                Picker("Words per flash", selection: Binding(
+                    get: { settings.chunkSize },
+                    set: { settings.setChunkSize($0) }
+                )) {
+                    Text("1").tag(1)
+                    Text("2").tag(2)
+                    Text("3").tag(3)
+                }
+                .pickerStyle(.segmented)
             } header: {
                 Text("Reading Speed")
             } footer: {
@@ -151,7 +171,8 @@ struct SettingsView: View {
                     font: settings.font,
                     fontSize: settings.fontSize,
                     theme: settings.theme,
-                    alignment: settings.alignment
+                    alignment: settings.alignment,
+                    chunkSize: settings.chunkSize
                 )
                     .accessibilityHidden(true)
 

--- a/SpeedReader/SpeedReaderExtension/Resources/background.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/background.js
@@ -31,7 +31,7 @@ async function syncSettingsFromNative() {
     );
     if (response && response.wpm !== undefined) {
       // Keep in sync with SETTINGS_KEYS in rsvp/settings-defaults.js
-      var allowed = ['wpm', 'font', 'theme', 'fontSize', 'punctuationPause', 'alignment'];
+      var allowed = ['wpm', 'font', 'theme', 'fontSize', 'punctuationPause', 'alignment', 'chunkSize'];
       var filtered = {};
       for (var i = 0; i < allowed.length; i++) {
         if (response[allowed[i]] !== undefined) {
@@ -75,6 +75,7 @@ browser.runtime.onInstalled.addListener(() => {
           fontSize: 42,
           punctuationPause: true,
           alignment: 'orp',
+          chunkSize: 1,
         });
       }
     })
@@ -106,7 +107,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return true;
     }
     // Keep in sync with SETTINGS_KEYS in rsvp/settings-defaults.js
-    var allowed = ['wpm', 'font', 'theme', 'fontSize', 'punctuationPause', 'alignment'];
+    var allowed = ['wpm', 'font', 'theme', 'fontSize', 'punctuationPause', 'alignment', 'chunkSize'];
     var filtered = {};
     for (var i = 0; i < allowed.length; i++) {
       if (raw[allowed[i]] !== undefined) {

--- a/SpeedReader/SpeedReaderExtension/Resources/content.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/content.js
@@ -149,6 +149,7 @@ var settingsDefaults = {
   fontSize: 42,
   punctuationPause: true,
   alignment: 'orp',
+  chunkSize: 1,
 };
 
 async function getSettings() {
@@ -237,6 +238,7 @@ window.addEventListener('message', function(event) {
       result.font = overlay.host.getAttribute('data-font') || 'default';
       result.fontSize = overlay.settings.fontSize || settingsDefaults.fontSize;
       result.alignment = overlay.host.getAttribute('data-alignment') || 'orp';
+      result.chunkSize = overlay.state.chunkSize || 1;
       result.wordTransform = wordEl ? wordEl.style.transform : '';
     }
     // Post result back to page context
@@ -257,7 +259,7 @@ window.addEventListener('message', function(event) {
   if (event.data.type === 'speedreader-test-dispatch') {
     var action = event.data.action;
     var payload = event.data.payload || {};
-    var overlayActions = ['set-theme', 'set-font', 'set-wpm', 'set-font-size', 'set-alignment'];
+    var overlayActions = ['set-theme', 'set-font', 'set-wpm', 'set-font-size', 'set-alignment', 'set-chunk-size'];
 
     if (overlayActions.indexOf(action) !== -1 && !overlay) {
       console.warn('[SpeedReader] dispatch ' + action + ' ignored: overlay not open');
@@ -273,6 +275,8 @@ window.addEventListener('message', function(event) {
       overlay.updateSettings({ fontSize: payload.fontSize });
     } else if (action === 'set-alignment') {
       overlay.updateSettings({ alignment: payload.alignment });
+    } else if (action === 'set-chunk-size') {
+      overlay.updateSettings({ chunkSize: payload.chunkSize });
     } else {
       console.warn('[SpeedReader] Unknown dispatch action:', action);
     }

--- a/SpeedReader/SpeedReaderExtension/Resources/manifest.json
+++ b/SpeedReader/SpeedReaderExtension/Resources/manifest.json
@@ -35,7 +35,7 @@
         "chunk-builder.js",
         "content-resolver.js",
         "Readability.js",
-        "fonts/OpenDyslexic-Regular.woff2"
+        "OpenDyslexic-Regular.woff2"
       ],
       "matches": ["<all_urls>"]
     }

--- a/SpeedReader/SpeedReaderExtension/Resources/manifest.json
+++ b/SpeedReader/SpeedReaderExtension/Resources/manifest.json
@@ -32,9 +32,10 @@
         "word-processor.js",
         "focus-point.js",
         "reading-position.js",
+        "chunk-builder.js",
         "content-resolver.js",
         "Readability.js",
-        "OpenDyslexic-Regular.woff2"
+        "fonts/OpenDyslexic-Regular.woff2"
       ],
       "matches": ["<all_urls>"]
     }

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js
@@ -1,0 +1,36 @@
+/**
+ * Groups word objects into display chunks, respecting sentence boundaries.
+ *
+ * @param {Array<{text: string, index: number, sentenceStart: boolean}>} words
+ * @param {number} chunkSize - 1, 2, or 3
+ * @returns {Array<{words: Array, startIndex: number, endIndex: number, text: string}>}
+ */
+export function buildChunks(words, chunkSize) {
+  if (words.length === 0) return [];
+
+  const chunks = [];
+  let i = 0;
+
+  while (i < words.length) {
+    const chunkWords = [words[i]];
+    let j = i + 1;
+
+    while (chunkWords.length < chunkSize && j < words.length) {
+      // Stop before a sentence start — don't cross sentence boundaries
+      if (words[j].sentenceStart) break;
+      chunkWords.push(words[j]);
+      j++;
+    }
+
+    chunks.push({
+      words: chunkWords,
+      startIndex: chunkWords[0].index,
+      endIndex: chunkWords[chunkWords.length - 1].index,
+      text: chunkWords.map(w => w.text).join(' '),
+    });
+
+    i = j;
+  }
+
+  return chunks;
+}

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
@@ -163,11 +163,13 @@
   color: var(--sr-text);
 }
 
-/* In chunk mode (centered alignment), reset the word container to inline
-   so _scaleWordToFit can measure true text width without grid interference. */
+/* In centered/chunk mode, let the word container size to its content
+   so _scaleWordToFit can measure true text width for scaling. */
 :host([data-alignment="center"]) .sr-word {
-  display: inline-block;
+  display: block;
+  width: max-content;
   min-width: auto;
+  max-width: none;
 }
 
 /* ORP-aligned: focus letter locked at horizontal center via CSS grid. */

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
@@ -160,7 +160,14 @@
 }
 
 .sr-chunk-text {
-  color: var(--sr-word-color, #e2e8f0);
+  color: var(--sr-text);
+}
+
+/* In chunk mode (centered alignment), reset the word container to inline
+   so _scaleWordToFit can measure true text width without grid interference. */
+:host([data-alignment="center"]) .sr-word {
+  display: inline-block;
+  min-width: auto;
 }
 
 /* ORP-aligned: focus letter locked at horizontal center via CSS grid. */

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
@@ -216,6 +216,39 @@
   background: rgba(61, 53, 32, 0.8);
 }
 
+.sr-tip-banner {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  margin: 0 16px;
+  border-radius: 8px;
+  background: var(--sr-accent, #0891b2);
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.sr-tip-banner[data-visible="true"] {
+  display: flex;
+}
+
+.sr-tip-dismiss {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 6px;
+  background: transparent;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.sr-tip-dismiss:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 .sr-controls {
   display: flex;
   align-items: center;

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css
@@ -159,6 +159,10 @@
   font-weight: 600;
 }
 
+.sr-chunk-text {
+  color: var(--sr-word-color, #e2e8f0);
+}
+
 /* ORP-aligned: focus letter locked at horizontal center via CSS grid. */
 :host([data-alignment="orp"]) .sr-word {
   display: grid;

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
@@ -413,8 +413,8 @@ export class RSVPOverlay {
       if (this.elements.tipBanner) {
         this.elements.tipBanner.setAttribute('data-visible', 'true');
       }
-    } catch (_e) {
-      // Silently skip tip if storage fails
+    } catch (e) {
+      console.warn('[SpeedReader] Tip check failed:', e.message || e);
     }
   }
 
@@ -422,7 +422,9 @@ export class RSVPOverlay {
     if (this.elements.tipBanner) {
       this.elements.tipBanner.setAttribute('data-visible', 'false');
     }
-    browser.storage.sync.set({ sr_chunkSizeTipSeen: true }).catch(() => {});
+    browser.storage.sync.set({ sr_chunkSizeTipSeen: true }).catch((e) => {
+      console.warn('[SpeedReader] Failed to persist tip dismissal:', e.message || e);
+    });
   }
 
   _showPageToast(message) {

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
@@ -61,6 +61,7 @@ export class RSVPOverlay {
     this._bindEvents();
     this._renderWord();
     this._updateProgress();
+    this._maybeShowTip();
   }
 
   updateSettings(settings) {
@@ -156,6 +157,7 @@ export class RSVPOverlay {
   }
 
   play() {
+    this._dismissTip();
     this.state.play();
     this._updatePlayButton();
     this._hideContext();
@@ -404,6 +406,25 @@ export class RSVPOverlay {
     }
   }
 
+  async _maybeShowTip() {
+    try {
+      const result = await browser.storage.sync.get({ sr_chunkSizeTipSeen: false });
+      if (result.sr_chunkSizeTipSeen) return;
+      if (this.elements.tipBanner) {
+        this.elements.tipBanner.setAttribute('data-visible', 'true');
+      }
+    } catch (_e) {
+      // Silently skip tip if storage fails
+    }
+  }
+
+  _dismissTip() {
+    if (this.elements.tipBanner) {
+      this.elements.tipBanner.setAttribute('data-visible', 'false');
+    }
+    browser.storage.sync.set({ sr_chunkSizeTipSeen: true }).catch(() => {});
+  }
+
   _showPageToast(message) {
     const toast = document.createElement('div');
     toast.style.cssText = [
@@ -529,6 +550,24 @@ export class RSVPOverlay {
 
     context.appendChild(contextLabel);
     context.appendChild(contextContent);
+
+    // Tip banner (shown once)
+    const tipBanner = document.createElement('div');
+    tipBanner.className = 'sr-tip-banner';
+    tipBanner.setAttribute('data-visible', 'false');
+
+    const tipText = document.createElement('span');
+    tipText.textContent = 'Tip: Try reading 2\u20133 words at a time. Change \u201CWords per flash\u201D in Settings.';
+
+    const tipDismiss = document.createElement('button');
+    tipDismiss.className = 'sr-tip-dismiss';
+    tipDismiss.textContent = 'Got it';
+    tipDismiss.setAttribute('aria-label', 'Dismiss tip');
+
+    tipBanner.appendChild(tipText);
+    tipBanner.appendChild(tipDismiss);
+    this.elements.tipBanner = tipBanner;
+    this.elements.tipDismiss = tipDismiss;
 
     // Controls
     const controls = document.createElement('div');
@@ -683,6 +722,7 @@ export class RSVPOverlay {
     card.appendChild(header);
     card.appendChild(wordArea);
     card.appendChild(context);
+    card.appendChild(tipBanner);
     card.appendChild(controls);
     card.appendChild(sliderArea);
     card.appendChild(fontSizeArea);
@@ -786,6 +826,13 @@ export class RSVPOverlay {
         this.close();
       }
     });
+
+    if (this.elements.tipDismiss) {
+      this.elements.tipDismiss.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._dismissTip();
+      });
+    }
 
     this._boundKeyHandler = (e) => {
       switch (e.key) {

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
@@ -36,6 +36,7 @@ export class RSVPOverlay {
     this.state.init(text, {
       wpm: settings.wpm,
       punctuationPause: settings.punctuationPause ?? true,
+      chunkSize: settings.chunkSize,
     });
 
     if (this.state.words.length === 0) {
@@ -99,6 +100,12 @@ export class RSVPOverlay {
     }
     if (settings.punctuationPause !== undefined) {
       this.state.punctuationPause = settings.punctuationPause;
+    }
+    if (typeof settings.chunkSize === 'number') {
+      this.state.rebuildChunks(settings.chunkSize);
+      this.pause();
+      this._renderWord();
+      this._updateProgress();
     }
   }
 
@@ -284,16 +291,32 @@ export class RSVPOverlay {
   }
 
   _renderWord() {
-    const parts = this.state.currentWord();
-    if (this.elements.wordBefore) {
-      this.elements.wordBefore.textContent = parts.before;
+    const display = this.state.currentDisplay();
+
+    if (display.isChunk) {
+      // Chunk mode: hide ORP spans, show plain text
+      if (this.elements.wordBefore) this.elements.wordBefore.textContent = '';
+      if (this.elements.wordFocus) this.elements.wordFocus.textContent = '';
+      if (this.elements.wordAfter) this.elements.wordAfter.textContent = '';
+      if (this.elements.chunkText) {
+        this.elements.chunkText.textContent = display.text;
+        this.elements.chunkText.style.display = '';
+      }
+    } else {
+      // ORP mode: hide chunk span, show split word
+      if (this.elements.chunkText) this.elements.chunkText.style.display = 'none';
+      if (this.elements.wordBefore) this.elements.wordBefore.textContent = display.before;
+      if (this.elements.wordFocus) this.elements.wordFocus.textContent = display.focus;
+      if (this.elements.wordAfter) this.elements.wordAfter.textContent = display.after;
     }
-    if (this.elements.wordFocus) {
-      this.elements.wordFocus.textContent = parts.focus;
+
+    // Chunk mode forces centered alignment — ORP anchor has no meaning with plain text
+    if (display.isChunk) {
+      this.host.setAttribute('data-alignment', 'center');
+    } else {
+      this.host.setAttribute('data-alignment', validateAlignment(this.settings.alignment));
     }
-    if (this.elements.wordAfter) {
-      this.elements.wordAfter.textContent = parts.after;
-    }
+
     this._scaleWordToFit();
   }
 
@@ -359,7 +382,12 @@ export class RSVPOverlay {
       if (i > 0) {
         contentEl.appendChild(document.createTextNode(' '));
       }
-      if (i === ctx.highlightIndex) {
+
+      const isHighlighted = ctx.highlightRange
+        ? (i >= ctx.highlightRange.start && i <= ctx.highlightRange.end)
+        : (i === ctx.highlightIndex);
+
+      if (isHighlighted) {
         const highlight = document.createElement('span');
         highlight.className = 'sr-context-highlight';
         highlight.textContent = ctx.words[i];
@@ -473,9 +501,15 @@ export class RSVPOverlay {
     wordAfter.className = 'sr-word-after';
     this.elements.wordAfter = wordAfter;
 
+    const chunkText = document.createElement('span');
+    chunkText.className = 'sr-chunk-text';
+    chunkText.style.display = 'none';
+    this.elements.chunkText = chunkText;
+
     wordContainer.appendChild(wordBefore);
     wordContainer.appendChild(wordFocus);
     wordContainer.appendChild(wordAfter);
+    wordContainer.appendChild(chunkText);
     this.elements.wordContainer = wordContainer;
 
     wordArea.appendChild(wordContainer);

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js
@@ -332,7 +332,10 @@ export class RSVPOverlay {
     // Reset any previous scale so measurements reflect true size.
     container.style.transform = '';
     const areaWidth = area.clientWidth;
-    const textWidth = container.scrollWidth;
+    // Use scrollWidth for grid/block layouts, but fall back to
+    // getBoundingClientRect for max-content containers (chunk mode)
+    // where scrollWidth may be clamped by the flex parent.
+    const textWidth = Math.max(container.scrollWidth, container.getBoundingClientRect().width);
     if (textWidth > areaWidth) {
       const scale = Math.max(areaWidth / textWidth, 0.3);
       container.style.transform = 'scale(' + scale + ')';

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js
@@ -8,10 +8,13 @@ export const FONT_SIZE_DEFAULT = 42;
 export const FONT_SIZE_MIN = 24;
 export const FONT_SIZE_MAX = 96;
 export const FONT_SIZE_STEP = 2;
+export const CHUNK_SIZE_DEFAULT = 1;
+export const CHUNK_SIZE_MIN = 1;
+export const CHUNK_SIZE_MAX = 3;
 export const ALIGNMENT_DEFAULT = 'orp';
 export const VALID_ALIGNMENTS = ['orp', 'center'];
 
-export const SETTINGS_KEYS = ['wpm', 'font', 'theme', 'fontSize', 'punctuationPause', 'alignment'];
+export const SETTINGS_KEYS = ['wpm', 'font', 'theme', 'fontSize', 'punctuationPause', 'alignment', 'chunkSize'];
 
 export const SETTINGS_DEFAULTS = {
   wpm: WPM_DEFAULT,
@@ -20,6 +23,7 @@ export const SETTINGS_DEFAULTS = {
   fontSize: FONT_SIZE_DEFAULT,
   punctuationPause: true,
   alignment: ALIGNMENT_DEFAULT,
+  chunkSize: CHUNK_SIZE_DEFAULT,
 };
 
 export function clampWpm(value) {
@@ -35,4 +39,9 @@ export function clampFontSize(value) {
 export function validateAlignment(value) {
   if (typeof value === 'string' && VALID_ALIGNMENTS.includes(value)) return value;
   return ALIGNMENT_DEFAULT;
+}
+
+export function clampChunkSize(value) {
+  if (typeof value !== 'number' || isNaN(value)) return CHUNK_SIZE_DEFAULT;
+  return Math.max(CHUNK_SIZE_MIN, Math.min(CHUNK_SIZE_MAX, value));
 }

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js
@@ -43,5 +43,5 @@ export function validateAlignment(value) {
 
 export function clampChunkSize(value) {
   if (typeof value !== 'number' || isNaN(value)) return CHUNK_SIZE_DEFAULT;
-  return Math.max(CHUNK_SIZE_MIN, Math.min(CHUNK_SIZE_MAX, value));
+  return Math.max(CHUNK_SIZE_MIN, Math.min(CHUNK_SIZE_MAX, Math.round(value)));
 }

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/state-machine.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/state-machine.js
@@ -1,4 +1,4 @@
-import { processText, wpmToDelay } from './word-processor.js';
+import { processText, calculateDelay, wpmToDelay } from './word-processor.js';
 import { splitWordAtFocus } from './focus-point.js';
 import { WPM_DEFAULT, CHUNK_SIZE_DEFAULT, clampWpm, clampChunkSize } from './settings-defaults.js';
 import { buildChunks } from './chunk-builder.js';
@@ -57,12 +57,7 @@ export class RSVPStateMachine {
 
     if (this.punctuationPause) {
       const lastWord = chunk.words[chunk.words.length - 1].text;
-      const lastChar = lastWord[lastWord.length - 1];
-      if ('.!?'.includes(lastChar)) {
-        delay = Math.round(delay * 1.5);
-      } else if (',:;'.includes(lastChar)) {
-        delay = Math.round(delay * 1.2);
-      }
+      delay = calculateDelay(lastWord, delay);
     }
 
     this.chunkIndex++;
@@ -112,6 +107,7 @@ export class RSVPStateMachine {
         return;
       }
     }
+    console.warn('[SpeedReader] seekTo: word index', wordIndex, 'did not match any chunk range; falling back to last chunk');
     this.chunkIndex = this.chunks.length - 1;
   }
 

--- a/SpeedReader/SpeedReaderExtension/Resources/rsvp/state-machine.js
+++ b/SpeedReader/SpeedReaderExtension/Resources/rsvp/state-machine.js
@@ -1,11 +1,14 @@
-import { processText, calculateDelay, wpmToDelay } from './word-processor.js';
+import { processText, wpmToDelay } from './word-processor.js';
 import { splitWordAtFocus } from './focus-point.js';
-import { WPM_DEFAULT, clampWpm } from './settings-defaults.js';
+import { WPM_DEFAULT, CHUNK_SIZE_DEFAULT, clampWpm, clampChunkSize } from './settings-defaults.js';
+import { buildChunks } from './chunk-builder.js';
 
 export class RSVPStateMachine {
   constructor() {
     this.words = [];
-    this.currentIndex = 0;
+    this.chunks = [];
+    this.chunkIndex = 0;
+    this.chunkSize = CHUNK_SIZE_DEFAULT;
     this.isPlaying = false;
     this.wpm = WPM_DEFAULT;
     this.punctuationPause = true;
@@ -13,15 +16,17 @@ export class RSVPStateMachine {
 
   init(text, settings = {}) {
     this.words = processText(text);
-    this.currentIndex = 0;
+    this.chunkSize = clampChunkSize(settings.chunkSize ?? CHUNK_SIZE_DEFAULT);
+    this.chunks = buildChunks(this.words, this.chunkSize);
+    this.chunkIndex = 0;
     this.isPlaying = false;
     this.wpm = clampWpm(settings.wpm ?? WPM_DEFAULT);
     this.punctuationPause = settings.punctuationPause ?? true;
   }
 
   play() {
-    if (this.currentIndex >= this.words.length) {
-      this.currentIndex = 0;
+    if (this.chunkIndex >= this.chunks.length) {
+      this.chunkIndex = 0;
     }
     this.isPlaying = true;
   }
@@ -39,22 +44,30 @@ export class RSVPStateMachine {
   }
 
   tick() {
-    if (!this.isPlaying || this.currentIndex >= this.words.length) {
-      if (this.currentIndex >= this.words.length) {
+    if (!this.isPlaying || this.chunkIndex >= this.chunks.length) {
+      if (this.chunkIndex >= this.chunks.length) {
         this.pause();
       }
       return { done: true };
     }
 
-    const word = this.words[this.currentIndex];
+    const chunk = this.chunks[this.chunkIndex];
     const baseDelay = wpmToDelay(this.wpm);
-    const delay = this.punctuationPause
-      ? calculateDelay(word.text, baseDelay)
-      : baseDelay;
+    let delay = baseDelay * chunk.words.length;
 
-    this.currentIndex++;
+    if (this.punctuationPause) {
+      const lastWord = chunk.words[chunk.words.length - 1].text;
+      const lastChar = lastWord[lastWord.length - 1];
+      if ('.!?'.includes(lastChar)) {
+        delay = Math.round(delay * 1.5);
+      } else if (',:;'.includes(lastChar)) {
+        delay = Math.round(delay * 1.2);
+      }
+    }
 
-    if (this.currentIndex >= this.words.length) {
+    this.chunkIndex++;
+
+    if (this.chunkIndex >= this.chunks.length) {
       this.pause();
       return { done: true, delay };
     }
@@ -64,27 +77,23 @@ export class RSVPStateMachine {
 
   prevSentence() {
     this.pause();
-    let i = this.currentIndex - 1;
+    let i = this.chunkIndex - 1;
     while (i > 0) {
-      if (this.words[i].sentenceStart) {
-        break;
-      }
+      if (this.chunks[i].words[0].sentenceStart) break;
       i--;
     }
-    this.currentIndex = Math.max(0, i);
+    this.chunkIndex = Math.max(0, i);
   }
 
   nextSentence() {
     this.pause();
-    let i = this.currentIndex + 1;
-    while (i < this.words.length) {
-      if (this.words[i].sentenceStart) {
-        break;
-      }
+    let i = this.chunkIndex + 1;
+    while (i < this.chunks.length) {
+      if (this.chunks[i].words[0].sentenceStart) break;
       i++;
     }
-    if (i < this.words.length) {
-      this.currentIndex = i;
+    if (i < this.chunks.length) {
+      this.chunkIndex = i;
     }
   }
 
@@ -93,22 +102,38 @@ export class RSVPStateMachine {
     this.pause();
     if (!Number.isInteger(index)) return;
     if (this.words.length === 0) {
-      this.currentIndex = 0;
+      this.chunkIndex = 0;
       return;
     }
-    this.currentIndex = Math.max(0, Math.min(index, this.words.length - 1));
+    const wordIndex = Math.max(0, Math.min(index, this.words.length - 1));
+    for (let i = 0; i < this.chunks.length; i++) {
+      if (wordIndex >= this.chunks[i].startIndex && wordIndex <= this.chunks[i].endIndex) {
+        this.chunkIndex = i;
+        return;
+      }
+    }
+    this.chunkIndex = this.chunks.length - 1;
+  }
+
+  _currentWordIndex() {
+    if (this.chunkIndex >= this.chunks.length) return this.words.length;
+    return this.chunks[this.chunkIndex].startIndex;
+  }
+
+  get currentIndex() {
+    return this._currentWordIndex();
   }
 
   // Returns whole seconds (ceil) of estimated elapsed reading time, always >= 0.
   timeElapsed() {
     if (this.words.length === 0) return 0;
-    return Math.ceil((this.currentIndex / this.wpm) * 60);
+    return Math.ceil((this._currentWordIndex() / this.wpm) * 60);
   }
 
   // Returns whole seconds (ceil) of estimated remaining reading time, always >= 0.
   timeRemaining() {
     if (this.words.length === 0) return 0;
-    const wordsLeft = this.words.length - this.currentIndex;
+    const wordsLeft = this.words.length - this._currentWordIndex();
     if (wordsLeft <= 0) return 0;
     return Math.ceil((wordsLeft / this.wpm) * 60);
   }
@@ -118,31 +143,48 @@ export class RSVPStateMachine {
     return this.wpm;
   }
 
-  currentWord() {
-    if (this.currentIndex >= this.words.length) {
-      return { before: '', focus: '', after: '' };
+  currentDisplay() {
+    if (this.chunkIndex >= this.chunks.length) {
+      return { before: '', focus: '', after: '', isChunk: false };
     }
-    return splitWordAtFocus(this.words[this.currentIndex].text);
+
+    const chunk = this.chunks[this.chunkIndex];
+    if (this.chunkSize > 1) {
+      return { text: chunk.text, isChunk: true };
+    }
+
+    const parts = splitWordAtFocus(chunk.words[0].text);
+    return { before: parts.before, focus: parts.focus, after: parts.after, isChunk: false };
+  }
+
+  // Backward-compat alias — overlay still calls this until Task 5
+  currentWord() {
+    const d = this.currentDisplay();
+    if (d.isChunk) return { before: '', focus: '', after: '' };
+    return { before: d.before, focus: d.focus, after: d.after };
   }
 
   progress() {
     const total = this.words.length;
-    const current = this.currentIndex;
+    const current = this._currentWordIndex();
     const percent = total > 0 ? Math.round((current / total) * 100) : 0;
     return { percent, current, total };
   }
 
   contextSentence() {
-    if (this.currentIndex >= this.words.length) {
+    if (this.chunkIndex >= this.chunks.length) {
       return { words: [], highlightIndex: -1 };
     }
 
-    let sentenceStart = this.currentIndex;
+    const chunk = this.chunks[this.chunkIndex];
+    const wordIndex = chunk.startIndex;
+
+    let sentenceStart = wordIndex;
     while (sentenceStart > 0 && !this.words[sentenceStart].sentenceStart) {
       sentenceStart--;
     }
 
-    let sentenceEnd = this.currentIndex + 1;
+    let sentenceEnd = wordIndex + 1;
     while (sentenceEnd < this.words.length && !this.words[sentenceEnd].sentenceStart) {
       sentenceEnd++;
     }
@@ -152,9 +194,20 @@ export class RSVPStateMachine {
       words.push(this.words[i].text);
     }
 
-    return {
-      words,
-      highlightIndex: this.currentIndex - sentenceStart,
-    };
+    const relativeStart = chunk.startIndex - sentenceStart;
+    const relativeEnd = chunk.endIndex - sentenceStart;
+
+    if (this.chunkSize === 1) {
+      return { words, highlightIndex: relativeStart };
+    }
+
+    return { words, highlightRange: { start: relativeStart, end: relativeEnd } };
+  }
+
+  rebuildChunks(newChunkSize) {
+    const wordIndex = this._currentWordIndex();
+    this.chunkSize = clampChunkSize(newChunkSize);
+    this.chunks = buildChunks(this.words, this.chunkSize);
+    this.seekTo(wordIndex);
   }
 }

--- a/SpeedReader/SpeedReaderExtension/SafariWebExtensionHandler.swift
+++ b/SpeedReader/SpeedReaderExtension/SafariWebExtensionHandler.swift
@@ -61,6 +61,8 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 ?? SettingsKeys.Defaults.punctuationPause,
             "alignment": defaults.string(forKey: SettingsKeys.alignment)
                 ?? SettingsKeys.Defaults.alignment.rawValue,
+            "chunkSize": defaults.object(forKey: SettingsKeys.chunkSize)
+                ?? SettingsKeys.Defaults.chunkSize,
         ]
     }
 
@@ -82,6 +84,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             "fontSize": SettingsKeys.Defaults.fontSize,
             "punctuationPause": SettingsKeys.Defaults.punctuationPause,
             "alignment": SettingsKeys.Defaults.alignment.rawValue,
+            "chunkSize": SettingsKeys.Defaults.chunkSize,
         ]
     }
 }

--- a/docs/plans/2026-04-06-chunk-size.md
+++ b/docs/plans/2026-04-06-chunk-size.md
@@ -1,0 +1,1399 @@
+# Configurable Chunk Size Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to display 1, 2, or 3 words at a time during RSVP playback, with sentence-boundary-aware chunking and a one-time feature tip.
+
+**Architecture:** New `chunk-builder.js` module produces chunks from word arrays. State machine consumes chunks instead of raw words, ticking one chunk per frame with proportional delay. Overlay renders ORP for single-word mode, plain text for chunk mode. Settings flow through JS defaults + Swift SettingsKeys + SwiftUI companion app.
+
+**Tech Stack:** JavaScript (ES modules, Node.js test runner), Swift/SwiftUI, Safari Web Extension APIs
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js` | Create | Pure function: `buildChunks(words, chunkSize) → chunk[]` |
+| `tests/js/chunk-builder.test.js` | Create | Unit tests for chunk building |
+| `SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js` | Modify | Add `CHUNK_SIZE_*` constants, `clampChunkSize()`, update `SETTINGS_KEYS`/`SETTINGS_DEFAULTS` |
+| `tests/js/settings-defaults.test.js` | Modify | Add `clampChunkSize()` tests |
+| `SpeedReader/SpeedReaderExtension/Resources/rsvp/state-machine.js` | Modify | Consume chunks, add `currentDisplay()`, chunk-aware navigation |
+| `tests/js/state-machine.test.js` | Modify | Add chunk-mode tests |
+| `SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js` | Modify | Dual render path, tip banner, chunk-aware context |
+| `SpeedReader/SpeedReaderExtension/Resources/content.js` | Modify | Add `chunkSize` to `settingsDefaults` and test query hook |
+| `SpeedReader/SpeedReaderExtension/Resources/manifest.json` | Modify | Register `chunk-builder.js` in `web_accessible_resources` |
+| `SpeedReader/Shared/SettingsKeys.swift` | Modify | Add `chunkSize` key, defaults, bounds, `saveSettings()` |
+| `SpeedReader/SpeedReader/Models/Settings.swift` | Modify | Add `chunkSize` property, setter, load logic |
+| `SpeedReader/SpeedReader/Views/SettingsView.swift` | Modify | Add "Words per flash" segmented control |
+
+---
+
+### Task 1: Settings defaults — JS side
+
+**Files:**
+- Modify: `SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js`
+- Modify: `tests/js/settings-defaults.test.js`
+
+- [ ] **Step 1: Write failing tests for `clampChunkSize()`**
+
+Add to `tests/js/settings-defaults.test.js`:
+
+```js
+describe('clampChunkSize', () => {
+  it('returns default for non-number input', () => {
+    assert.strictEqual(clampChunkSize('two'), 1);
+    assert.strictEqual(clampChunkSize(NaN), 1);
+    assert.strictEqual(clampChunkSize(undefined), 1);
+  });
+
+  it('clamps below minimum to 1', () => {
+    assert.strictEqual(clampChunkSize(0), 1);
+    assert.strictEqual(clampChunkSize(-1), 1);
+  });
+
+  it('clamps above maximum to 3', () => {
+    assert.strictEqual(clampChunkSize(4), 3);
+    assert.strictEqual(clampChunkSize(99), 3);
+  });
+
+  it('accepts valid values', () => {
+    assert.strictEqual(clampChunkSize(1), 1);
+    assert.strictEqual(clampChunkSize(2), 2);
+    assert.strictEqual(clampChunkSize(3), 3);
+  });
+});
+```
+
+Update the import at the top of the file to include `clampChunkSize`, `CHUNK_SIZE_DEFAULT`, `CHUNK_SIZE_MIN`, `CHUNK_SIZE_MAX`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/js/settings-defaults.test.js`
+Expected: FAIL — `clampChunkSize` is not exported
+
+- [ ] **Step 3: Implement settings constants and clampChunkSize**
+
+Add to `settings-defaults.js` after the existing `FONT_SIZE_STEP` line:
+
+```js
+export const CHUNK_SIZE_DEFAULT = 1;
+export const CHUNK_SIZE_MIN = 1;
+export const CHUNK_SIZE_MAX = 3;
+```
+
+Add `'chunkSize'` to `SETTINGS_KEYS`:
+
+```js
+export const SETTINGS_KEYS = ['wpm', 'font', 'theme', 'fontSize', 'punctuationPause', 'alignment', 'chunkSize'];
+```
+
+Add `chunkSize: CHUNK_SIZE_DEFAULT` to `SETTINGS_DEFAULTS`.
+
+Add the clamp function after `validateAlignment`:
+
+```js
+export function clampChunkSize(value) {
+  if (typeof value !== 'number' || isNaN(value)) return CHUNK_SIZE_DEFAULT;
+  return Math.max(CHUNK_SIZE_MIN, Math.min(CHUNK_SIZE_MAX, value));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/js/settings-defaults.test.js`
+Expected: All tests PASS
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js tests/js/settings-defaults.test.js
+git commit -m "Add chunkSize settings constants and clampChunkSize validator (#18)"
+```
+
+---
+
+### Task 2: Chunk builder module
+
+**Files:**
+- Create: `SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js`
+- Create: `tests/js/chunk-builder.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/js/chunk-builder.test.js`:
+
+```js
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildChunks } from '../../SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js';
+
+describe('buildChunks', () => {
+
+  // Helper: create word objects matching processText() output shape
+  function words(texts) {
+    let nextIsSentenceStart = true;
+    return texts.map((text, index) => {
+      const entry = { text, index, sentenceStart: nextIsSentenceStart };
+      nextIsSentenceStart = /[.!?]$/.test(text);
+      return entry;
+    });
+  }
+
+  describe('chunkSize = 1', () => {
+    it('produces one chunk per word', () => {
+      const w = words(['Hello', 'world.']);
+      const chunks = buildChunks(w, 1);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'Hello');
+      assert.strictEqual(chunks[0].startIndex, 0);
+      assert.strictEqual(chunks[0].endIndex, 0);
+      assert.strictEqual(chunks[1].text, 'world.');
+      assert.strictEqual(chunks[1].startIndex, 1);
+      assert.strictEqual(chunks[1].endIndex, 1);
+    });
+  });
+
+  describe('chunkSize = 2', () => {
+    it('groups words into pairs', () => {
+      const w = words(['The', 'quick', 'brown', 'fox.']);
+      const chunks = buildChunks(w, 2);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'The quick');
+      assert.strictEqual(chunks[0].startIndex, 0);
+      assert.strictEqual(chunks[0].endIndex, 1);
+      assert.strictEqual(chunks[1].text, 'brown fox.');
+      assert.strictEqual(chunks[1].startIndex, 2);
+      assert.strictEqual(chunks[1].endIndex, 3);
+    });
+
+    it('handles odd word count with shorter final chunk', () => {
+      const w = words(['One', 'two', 'three.']);
+      const chunks = buildChunks(w, 2);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'One two');
+      assert.strictEqual(chunks[1].text, 'three.');
+      assert.strictEqual(chunks[1].words.length, 1);
+    });
+  });
+
+  describe('chunkSize = 3', () => {
+    it('groups words into triples', () => {
+      const w = words(['The', 'quick', 'brown', 'fox', 'jumps', 'over.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'The quick brown');
+      assert.strictEqual(chunks[1].text, 'fox jumps over.');
+    });
+  });
+
+  describe('sentence boundaries', () => {
+    it('breaks chunk at sentence boundary', () => {
+      const w = words(['Hello', 'world.', 'Goodbye', 'world.']);
+      const chunks = buildChunks(w, 3);
+      // "Hello world." is one chunk (2 words, shorter than 3 because sentence ends)
+      // "Goodbye world." is another chunk
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'Hello world.');
+      assert.strictEqual(chunks[0].words.length, 2);
+      assert.strictEqual(chunks[1].text, 'Goodbye world.');
+      assert.strictEqual(chunks[1].words.length, 2);
+    });
+
+    it('produces single-word chunk when sentence is one word', () => {
+      const w = words(['Stop.', 'Go.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'Stop.');
+      assert.strictEqual(chunks[1].text, 'Go.');
+    });
+
+    it('handles sentence boundary at position 2 of a 3-word chunk', () => {
+      // "A B. C D E." — chunk size 3
+      // Chunk 1: "A B." (sentence ends at B)
+      // Chunk 2: "C D E."
+      const w = words(['A', 'B.', 'C', 'D', 'E.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'A B.');
+      assert.strictEqual(chunks[1].text, 'C D E.');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input', () => {
+      assert.deepStrictEqual(buildChunks([], 2), []);
+    });
+
+    it('handles single word', () => {
+      const w = words(['Hello.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 1);
+      assert.strictEqual(chunks[0].text, 'Hello.');
+    });
+
+    it('chunk words array contains references to original word objects', () => {
+      const w = words(['The', 'cat.']);
+      const chunks = buildChunks(w, 2);
+      assert.strictEqual(chunks[0].words[0], w[0]);
+      assert.strictEqual(chunks[0].words[1], w[1]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/js/chunk-builder.test.js`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `buildChunks()`**
+
+Create `SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js`:
+
+```js
+/**
+ * Groups word objects into display chunks, respecting sentence boundaries.
+ *
+ * @param {Array<{text: string, index: number, sentenceStart: boolean}>} words
+ * @param {number} chunkSize - 1, 2, or 3
+ * @returns {Array<{words: Array, startIndex: number, endIndex: number, text: string}>}
+ */
+export function buildChunks(words, chunkSize) {
+  if (words.length === 0) return [];
+
+  const chunks = [];
+  let i = 0;
+
+  while (i < words.length) {
+    const chunkWords = [words[i]];
+    let j = i + 1;
+
+    while (chunkWords.length < chunkSize && j < words.length) {
+      // Stop before a sentence start — don't cross sentence boundaries
+      if (words[j].sentenceStart) break;
+      chunkWords.push(words[j]);
+      j++;
+    }
+
+    chunks.push({
+      words: chunkWords,
+      startIndex: chunkWords[0].index,
+      endIndex: chunkWords[chunkWords.length - 1].index,
+      text: chunkWords.map(w => w.text).join(' '),
+    });
+
+    i = j;
+  }
+
+  return chunks;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/js/chunk-builder.test.js`
+Expected: All tests PASS
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js tests/js/chunk-builder.test.js
+git commit -m "Add chunk-builder module with sentence-boundary-aware grouping (#18)"
+```
+
+---
+
+### Task 3: State machine — chunk integration
+
+**Files:**
+- Modify: `SpeedReader/SpeedReaderExtension/Resources/rsvp/state-machine.js`
+- Modify: `tests/js/state-machine.test.js`
+
+- [ ] **Step 1: Write failing tests for chunk mode**
+
+Add to `tests/js/state-machine.test.js`. Add this new `describe` block after the existing `contextSentence` describe:
+
+```js
+describe('chunk mode (chunkSize > 1)', () => {
+
+  describe('init with chunkSize', () => {
+    it('builds chunks from words', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { chunkSize: 2 });
+      assert.strictEqual(sm.chunks.length, 2); // "The quick" + "brown fox."
+      assert.strictEqual(sm.chunkIndex, 0);
+    });
+
+    it('defaults to chunkSize 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.');
+      assert.strictEqual(sm.chunkSize, 1);
+      assert.strictEqual(sm.chunks.length, 2); // one chunk per word
+    });
+  });
+
+  describe('tick with chunks', () => {
+    it('advances chunkIndex by 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { wpm: 250, chunkSize: 2 });
+      sm.play();
+      const result = sm.tick();
+      assert.strictEqual(sm.chunkIndex, 1);
+      assert.strictEqual(result.done, undefined);
+    });
+
+    it('returns delay proportional to words in chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { wpm: 250, chunkSize: 2 });
+      sm.play();
+      const result = sm.tick();
+      // 2-word chunk: baseDelay (240) * 2 = 480
+      assert.strictEqual(result.delay, 480);
+    });
+
+    it('applies punctuation pause to last word in chunk only', () => {
+      const sm = new RSVPStateMachine();
+      // "Hello world." is one 2-word chunk, last word has period
+      sm.init('Hello world.', { wpm: 250, chunkSize: 2, punctuationPause: true });
+      sm.play();
+      const result = sm.tick();
+      // baseDelay=240, 2 words=480, period on last word=480*1.5=720
+      assert.strictEqual(result.delay, Math.round(480 * 1.5));
+    });
+
+    it('returns done at last chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.', { chunkSize: 2 });
+      sm.play();
+      // Only one chunk: "Hello world."
+      const result = sm.tick();
+      assert.strictEqual(result.done, true);
+      assert.strictEqual(sm.isPlaying, false);
+    });
+  });
+
+  describe('currentDisplay', () => {
+    it('returns isChunk false with ORP split for chunkSize 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Reading.', { chunkSize: 1 });
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, false);
+      assert.strictEqual(typeof d.before, 'string');
+      assert.strictEqual(typeof d.focus, 'string');
+      assert.strictEqual(typeof d.after, 'string');
+    });
+
+    it('returns isChunk true with plain text for chunkSize 2', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.', { chunkSize: 2 });
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, true);
+      assert.strictEqual(d.text, 'Hello world.');
+    });
+
+    it('returns empty display past end', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hi.', { chunkSize: 2 });
+      sm.chunkIndex = sm.chunks.length;
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, false);
+      assert.strictEqual(d.before, '');
+      assert.strictEqual(d.focus, '');
+      assert.strictEqual(d.after, '');
+    });
+  });
+
+  describe('sentence navigation with chunks', () => {
+    it('prevSentence jumps to chunk containing previous sentence start', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('First sentence. Second sentence.', { chunkSize: 2 });
+      sm.play();
+      // chunks: ["First sentence."], ["Second sentence."]
+      sm.chunkIndex = 1;
+      sm.prevSentence();
+      assert.strictEqual(sm.chunkIndex, 0);
+    });
+
+    it('nextSentence jumps to chunk containing next sentence start', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('First sentence. Second sentence.', { chunkSize: 2 });
+      sm.play();
+      sm.chunkIndex = 0;
+      sm.nextSentence();
+      assert.strictEqual(sm.chunkIndex, 1);
+    });
+  });
+
+  describe('seekTo with chunks', () => {
+    it('maps word index to correct chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      // chunks: ["One two"], ["three four."]
+      sm.seekTo(2); // word "three" is in chunk 1
+      assert.strictEqual(sm.chunkIndex, 1);
+    });
+
+    it('maps word index 0 to chunk 0', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      sm.seekTo(0);
+      assert.strictEqual(sm.chunkIndex, 0);
+    });
+  });
+
+  describe('progress with chunks', () => {
+    it('reports word-level progress not chunk-level', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      sm.chunkIndex = 1; // chunk 1 starts at word index 2
+      const p = sm.progress();
+      assert.strictEqual(p.current, 2); // word index, not chunk index
+      assert.strictEqual(p.total, 4);
+      assert.strictEqual(p.percent, 50);
+    });
+  });
+
+  describe('timeElapsed and timeRemaining with chunks', () => {
+    it('computes from word position not chunk position', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { wpm: 240, chunkSize: 2 });
+      sm.chunkIndex = 1; // word index 2
+      // elapsed: ceil(2/240*60) = ceil(0.5) = 1
+      assert.strictEqual(sm.timeElapsed(), 1);
+      // remaining: ceil(2/240*60) = ceil(0.5) = 1
+      assert.strictEqual(sm.timeRemaining(), 1);
+    });
+  });
+
+  describe('contextSentence with chunks', () => {
+    it('returns highlightRange for multi-word chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { chunkSize: 2 });
+      // chunk 0: "The quick" (words 0-1), chunk 1: "brown fox." (words 2-3)
+      sm.chunkIndex = 0;
+      const ctx = sm.contextSentence();
+      assert.deepStrictEqual(ctx.highlightRange, { start: 0, end: 1 });
+    });
+
+    it('returns single highlightIndex for chunkSize 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.', { chunkSize: 1 });
+      sm.chunkIndex = 0;
+      const ctx = sm.contextSentence();
+      assert.strictEqual(ctx.highlightIndex, 0);
+      assert.strictEqual(ctx.highlightRange, undefined);
+    });
+  });
+
+  describe('backward compatibility (chunkSize 1)', () => {
+    it('tick advances same as before', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world again.', { wpm: 250, chunkSize: 1 });
+      sm.play();
+      const result = sm.tick();
+      assert.strictEqual(sm.chunkIndex, 1);
+      assert.strictEqual(result.delay, 240); // single word, baseDelay * 1
+    });
+
+    it('currentDisplay returns ORP split', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Reading.', { chunkSize: 1 });
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, false);
+      assert.strictEqual(d.before, 'Re');
+      assert.strictEqual(d.focus, 'a');
+      assert.strictEqual(d.after, 'ding.');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/js/state-machine.test.js`
+Expected: FAIL — `chunks` property undefined, `currentDisplay` not a function
+
+- [ ] **Step 3: Implement chunk integration in state machine**
+
+Replace the full contents of `state-machine.js` with the chunk-aware version. Key changes from current code:
+
+1. Import `buildChunks` and `clampChunkSize`:
+
+```js
+import { processText, calculateDelay, wpmToDelay } from './word-processor.js';
+import { splitWordAtFocus } from './focus-point.js';
+import { WPM_DEFAULT, CHUNK_SIZE_DEFAULT, clampWpm, clampChunkSize } from './settings-defaults.js';
+import { buildChunks } from './chunk-builder.js';
+```
+
+2. Constructor adds new properties:
+
+```js
+constructor() {
+  this.words = [];
+  this.chunks = [];
+  this.chunkIndex = 0;
+  this.chunkSize = CHUNK_SIZE_DEFAULT;
+  this.isPlaying = false;
+  this.wpm = WPM_DEFAULT;
+  this.punctuationPause = true;
+}
+```
+
+3. `init()` builds chunks:
+
+```js
+init(text, settings = {}) {
+  this.words = processText(text);
+  this.chunkSize = clampChunkSize(settings.chunkSize ?? CHUNK_SIZE_DEFAULT);
+  this.chunks = buildChunks(this.words, this.chunkSize);
+  this.chunkIndex = 0;
+  this.isPlaying = false;
+  this.wpm = clampWpm(settings.wpm ?? WPM_DEFAULT);
+  this.punctuationPause = settings.punctuationPause ?? true;
+}
+```
+
+4. `play()` resets based on chunks:
+
+```js
+play() {
+  if (this.chunkIndex >= this.chunks.length) {
+    this.chunkIndex = 0;
+  }
+  this.isPlaying = true;
+}
+```
+
+5. `tick()` uses chunks with proportional delay:
+
+```js
+tick() {
+  if (!this.isPlaying || this.chunkIndex >= this.chunks.length) {
+    if (this.chunkIndex >= this.chunks.length) {
+      this.pause();
+    }
+    return { done: true };
+  }
+
+  const chunk = this.chunks[this.chunkIndex];
+  const baseDelay = wpmToDelay(this.wpm);
+  let delay = baseDelay * chunk.words.length;
+
+  if (this.punctuationPause) {
+    const lastWord = chunk.words[chunk.words.length - 1].text;
+    const lastChar = lastWord[lastWord.length - 1];
+    if ('.!?'.includes(lastChar)) {
+      delay = Math.round(delay * 1.5);
+    } else if (',:;'.includes(lastChar)) {
+      delay = Math.round(delay * 1.2);
+    }
+  }
+
+  this.chunkIndex++;
+
+  if (this.chunkIndex >= this.chunks.length) {
+    this.pause();
+    return { done: true, delay };
+  }
+
+  return { delay };
+}
+```
+
+6. `currentDisplay()` replaces `currentWord()`:
+
+```js
+currentDisplay() {
+  if (this.chunkIndex >= this.chunks.length) {
+    return { before: '', focus: '', after: '', isChunk: false };
+  }
+
+  const chunk = this.chunks[this.chunkIndex];
+  if (this.chunkSize > 1) {
+    return { text: chunk.text, isChunk: true };
+  }
+
+  const parts = splitWordAtFocus(chunk.words[0].text);
+  return { before: parts.before, focus: parts.focus, after: parts.after, isChunk: false };
+}
+```
+
+Keep `currentWord()` as an alias for backward compatibility with overlay code until Task 5 updates it:
+
+```js
+currentWord() {
+  const d = this.currentDisplay();
+  if (d.isChunk) return { before: '', focus: '', after: '' };
+  return { before: d.before, focus: d.focus, after: d.after };
+}
+```
+
+7. `prevSentence()` navigates chunks:
+
+```js
+prevSentence() {
+  this.pause();
+  let i = this.chunkIndex - 1;
+  while (i > 0) {
+    if (this.chunks[i].words[0].sentenceStart) break;
+    i--;
+  }
+  this.chunkIndex = Math.max(0, i);
+}
+```
+
+8. `nextSentence()` navigates chunks:
+
+```js
+nextSentence() {
+  this.pause();
+  let i = this.chunkIndex + 1;
+  while (i < this.chunks.length) {
+    if (this.chunks[i].words[0].sentenceStart) break;
+    i++;
+  }
+  if (i < this.chunks.length) {
+    this.chunkIndex = i;
+  }
+}
+```
+
+9. `seekTo()` maps word index to chunk:
+
+```js
+seekTo(index) {
+  this.pause();
+  if (!Number.isInteger(index)) return;
+  if (this.words.length === 0) {
+    this.chunkIndex = 0;
+    return;
+  }
+  const wordIndex = Math.max(0, Math.min(index, this.words.length - 1));
+  // Find the chunk containing this word index
+  for (let i = 0; i < this.chunks.length; i++) {
+    if (wordIndex >= this.chunks[i].startIndex && wordIndex <= this.chunks[i].endIndex) {
+      this.chunkIndex = i;
+      return;
+    }
+  }
+  this.chunkIndex = this.chunks.length - 1;
+}
+```
+
+10. `progress()`, `timeElapsed()`, `timeRemaining()` use word-level position via `_currentWordIndex()`:
+
+```js
+_currentWordIndex() {
+  if (this.chunkIndex >= this.chunks.length) return this.words.length;
+  return this.chunks[this.chunkIndex].startIndex;
+}
+
+timeElapsed() {
+  if (this.words.length === 0) return 0;
+  return Math.ceil((this._currentWordIndex() / this.wpm) * 60);
+}
+
+timeRemaining() {
+  if (this.words.length === 0) return 0;
+  const wordsLeft = this.words.length - this._currentWordIndex();
+  if (wordsLeft <= 0) return 0;
+  return Math.ceil((wordsLeft / this.wpm) * 60);
+}
+
+progress() {
+  const total = this.words.length;
+  const current = this._currentWordIndex();
+  const percent = total > 0 ? Math.round((current / total) * 100) : 0;
+  return { percent, current, total };
+}
+```
+
+11. `contextSentence()` returns highlight range for chunks:
+
+```js
+contextSentence() {
+  if (this.chunkIndex >= this.chunks.length) {
+    return { words: [], highlightIndex: -1 };
+  }
+
+  const chunk = this.chunks[this.chunkIndex];
+  const wordIndex = chunk.startIndex;
+
+  let sentenceStart = wordIndex;
+  while (sentenceStart > 0 && !this.words[sentenceStart].sentenceStart) {
+    sentenceStart--;
+  }
+
+  let sentenceEnd = wordIndex + 1;
+  while (sentenceEnd < this.words.length && !this.words[sentenceEnd].sentenceStart) {
+    sentenceEnd++;
+  }
+
+  const words = [];
+  for (let i = sentenceStart; i < sentenceEnd; i++) {
+    words.push(this.words[i].text);
+  }
+
+  const relativeStart = chunk.startIndex - sentenceStart;
+  const relativeEnd = chunk.endIndex - sentenceStart;
+
+  if (this.chunkSize === 1) {
+    return { words, highlightIndex: relativeStart };
+  }
+
+  return { words, highlightRange: { start: relativeStart, end: relativeEnd } };
+}
+```
+
+12. Add `rebuildChunks()` for mid-session chunk size changes:
+
+```js
+rebuildChunks(newChunkSize) {
+  const wordIndex = this._currentWordIndex();
+  this.chunkSize = clampChunkSize(newChunkSize);
+  this.chunks = buildChunks(this.words, this.chunkSize);
+  this.seekTo(wordIndex);
+}
+```
+
+Also add a `currentIndex` getter for backward compatibility with overlay code that reads `state.currentIndex` (scrubber, content.js test hooks):
+
+```js
+get currentIndex() {
+  return this._currentWordIndex();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/js/state-machine.test.js`
+Expected: All tests PASS (both new chunk tests and existing tests)
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SpeedReader/SpeedReaderExtension/Resources/rsvp/state-machine.js tests/js/state-machine.test.js
+git commit -m "Integrate chunk-builder into state machine with proportional delay (#18)"
+```
+
+---
+
+### Task 4: Register chunk-builder.js in manifest
+
+**Files:**
+- Modify: `SpeedReader/SpeedReaderExtension/Resources/manifest.json`
+
+- [ ] **Step 1: Add chunk-builder.js to web_accessible_resources**
+
+In `manifest.json`, add `"chunk-builder.js"` to the resources array after `"reading-position.js"`:
+
+```json
+"resources": [
+  "overlay.css",
+  "overlay.js",
+  "state-machine.js",
+  "settings-defaults.js",
+  "word-processor.js",
+  "focus-point.js",
+  "reading-position.js",
+  "chunk-builder.js",
+  "content-resolver.js",
+  "Readability.js",
+  "fonts/OpenDyslexic-Regular.woff2"
+],
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add SpeedReader/SpeedReaderExtension/Resources/manifest.json
+git commit -m "Register chunk-builder.js in manifest web_accessible_resources (#18)"
+```
+
+---
+
+### Task 5: Overlay — dual rendering and chunk-aware context
+
+**Files:**
+- Modify: `SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js`
+
+- [ ] **Step 1: Add chunk text element to DOM creation**
+
+In `_createDOM()`, after creating `wordAfter` and before `wordContainer.appendChild(wordBefore)`, add the chunk text span:
+
+```js
+const chunkText = document.createElement('span');
+chunkText.className = 'sr-chunk-text';
+chunkText.style.display = 'none';
+this.elements.chunkText = chunkText;
+```
+
+Add it to `wordContainer` after the three ORP spans:
+
+```js
+wordContainer.appendChild(wordBefore);
+wordContainer.appendChild(wordFocus);
+wordContainer.appendChild(wordAfter);
+wordContainer.appendChild(chunkText);
+```
+
+- [ ] **Step 2: Update `_renderWord()` to use `currentDisplay()`**
+
+Replace the `_renderWord()` method:
+
+```js
+_renderWord() {
+  const display = this.state.currentDisplay();
+
+  if (display.isChunk) {
+    // Chunk mode: hide ORP spans, show plain text
+    if (this.elements.wordBefore) this.elements.wordBefore.textContent = '';
+    if (this.elements.wordFocus) this.elements.wordFocus.textContent = '';
+    if (this.elements.wordAfter) this.elements.wordAfter.textContent = '';
+    if (this.elements.chunkText) {
+      this.elements.chunkText.textContent = display.text;
+      this.elements.chunkText.style.display = '';
+    }
+  } else {
+    // ORP mode: hide chunk span, show split word
+    if (this.elements.chunkText) this.elements.chunkText.style.display = 'none';
+    if (this.elements.wordBefore) this.elements.wordBefore.textContent = display.before;
+    if (this.elements.wordFocus) this.elements.wordFocus.textContent = display.focus;
+    if (this.elements.wordAfter) this.elements.wordAfter.textContent = display.after;
+  }
+
+  this._scaleWordToFit();
+}
+```
+
+- [ ] **Step 3: Update `_showContext()` for chunk highlight range**
+
+Replace the context rendering loop in `_showContext()`:
+
+```js
+_showContext() {
+  if (!this.elements.context) return;
+  this.elements.context.setAttribute('data-visible', 'true');
+
+  const contentEl = this.elements.contextContent;
+  if (!contentEl) return;
+
+  while (contentEl.firstChild) {
+    contentEl.removeChild(contentEl.firstChild);
+  }
+
+  const ctx = this.state.contextSentence();
+  if (ctx.words.length === 0) return;
+
+  for (let i = 0; i < ctx.words.length; i++) {
+    if (i > 0) {
+      contentEl.appendChild(document.createTextNode(' '));
+    }
+
+    const isHighlighted = ctx.highlightRange
+      ? (i >= ctx.highlightRange.start && i <= ctx.highlightRange.end)
+      : (i === ctx.highlightIndex);
+
+    if (isHighlighted) {
+      const highlight = document.createElement('span');
+      highlight.className = 'sr-context-highlight';
+      highlight.textContent = ctx.words[i];
+      contentEl.appendChild(highlight);
+    } else {
+      contentEl.appendChild(document.createTextNode(ctx.words[i]));
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Update `_updateProgress()` scrubber max**
+
+The scrubber max should still use word count. No changes needed — `this.state.words.length` is still accessible. Verify the existing code uses `this.state.words.length` for `scrubber.max` in `_createDOM()` and `this.state.currentIndex` (now a getter) for the value.
+
+- [ ] **Step 5: Pass chunkSize through `open()` and `updateSettings()`**
+
+In `open()`, pass `chunkSize` to `state.init()`:
+
+```js
+this.state.init(text, {
+  wpm: settings.wpm,
+  punctuationPause: settings.punctuationPause ?? true,
+  chunkSize: settings.chunkSize,
+});
+```
+
+In `updateSettings()`, handle `chunkSize` changes:
+
+```js
+if (typeof settings.chunkSize === 'number') {
+  this.state.rebuildChunks(settings.chunkSize);
+  this.pause();
+  this._renderWord();
+  this._updateProgress();
+}
+```
+
+- [ ] **Step 6: Handle alignment fallback for chunk mode**
+
+In `_createDOM()`, after setting the alignment attribute, and in `_renderWord()`, add alignment switching:
+
+In `_renderWord()`, after the existing render logic and before `_scaleWordToFit()`:
+
+```js
+// Chunk mode forces centered alignment — ORP anchor has no meaning with plain text
+if (display.isChunk) {
+  this.host.setAttribute('data-alignment', 'center');
+} else {
+  this.host.setAttribute('data-alignment', validateAlignment(this.settings.alignment));
+}
+```
+
+Add `validateAlignment` to the import at the top of overlay.js (it's already imported, verify).
+
+- [ ] **Step 7: Style the chunk text span**
+
+Add CSS for `.sr-chunk-text` in `overlay.css`. The chunk text should match the existing word color but without the focus highlight. Find the `.sr-word-before` and `.sr-word-after` color declarations and apply the same to `.sr-chunk-text`:
+
+```css
+.sr-chunk-text {
+  color: var(--sr-word-color, #e2e8f0);
+}
+```
+
+- [ ] **Step 8: Run unit tests**
+
+Run: `make test-js`
+Expected: All tests PASS
+
+- [ ] **Step 9: Lint**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js SpeedReader/SpeedReaderExtension/Resources/overlay.css
+git commit -m "Add dual render path for ORP and chunk display modes (#18)"
+```
+
+---
+
+### Task 6: One-time tip banner
+
+**Files:**
+- Modify: `SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js`
+
+- [ ] **Step 1: Add tip banner DOM in `_createDOM()`**
+
+After the context element and before the controls element, add:
+
+```js
+// Tip banner (shown once)
+const tipBanner = document.createElement('div');
+tipBanner.className = 'sr-tip-banner';
+tipBanner.setAttribute('data-visible', 'false');
+
+const tipText = document.createElement('span');
+tipText.textContent = 'Tip: Try reading 2\u20133 words at a time. Change \u201CWords per flash\u201D in Settings.';
+
+const tipDismiss = document.createElement('button');
+tipDismiss.className = 'sr-tip-dismiss';
+tipDismiss.textContent = 'Got it';
+tipDismiss.setAttribute('aria-label', 'Dismiss tip');
+
+tipBanner.appendChild(tipText);
+tipBanner.appendChild(tipDismiss);
+this.elements.tipBanner = tipBanner;
+this.elements.tipDismiss = tipDismiss;
+```
+
+Add `tipBanner` to the card assembly, between `context` and `controls`:
+
+```js
+card.appendChild(context);
+card.appendChild(tipBanner);
+card.appendChild(controls);
+```
+
+- [ ] **Step 2: Show tip on first open, hide on dismiss or play**
+
+Add a method to check and show the tip. Call it at the end of `open()`, after `_renderWord()`:
+
+```js
+async _maybeShowTip() {
+  try {
+    const result = await browser.storage.sync.get({ sr_chunkSizeTipSeen: false });
+    if (result.sr_chunkSizeTipSeen) return;
+    if (this.elements.tipBanner) {
+      this.elements.tipBanner.setAttribute('data-visible', 'true');
+    }
+  } catch (e) {
+    // Silently skip tip if storage fails
+  }
+}
+
+_dismissTip() {
+  if (this.elements.tipBanner) {
+    this.elements.tipBanner.setAttribute('data-visible', 'false');
+  }
+  browser.storage.sync.set({ sr_chunkSizeTipSeen: true }).catch(() => {});
+}
+```
+
+In `open()`, after `this._updateProgress();`:
+
+```js
+this._maybeShowTip();
+```
+
+In `play()`, add at the start:
+
+```js
+this._dismissTip();
+```
+
+- [ ] **Step 3: Bind dismiss button**
+
+In `_bindEvents()`, add:
+
+```js
+if (this.elements.tipDismiss) {
+  this.elements.tipDismiss.addEventListener('click', (e) => {
+    e.stopPropagation();
+    this._dismissTip();
+  });
+}
+```
+
+- [ ] **Step 4: Style the tip banner**
+
+Add to `overlay.css`:
+
+```css
+.sr-tip-banner {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  margin: 0 16px;
+  border-radius: 8px;
+  background: var(--sr-accent, #0891b2);
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.sr-tip-banner[data-visible="true"] {
+  display: flex;
+}
+
+.sr-tip-dismiss {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 6px;
+  background: transparent;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.sr-tip-dismiss:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+```
+
+- [ ] **Step 5: Run unit tests**
+
+Run: `make test-js`
+Expected: All tests PASS
+
+- [ ] **Step 6: Lint**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.js SpeedReader/SpeedReaderExtension/Resources/overlay.css
+git commit -m "Add one-time tip banner for chunk size feature discovery (#18)"
+```
+
+---
+
+### Task 7: Content script — settings defaults and test hooks
+
+**Files:**
+- Modify: `SpeedReader/SpeedReaderExtension/Resources/content.js`
+
+- [ ] **Step 1: Add chunkSize to settingsDefaults**
+
+In `content.js`, update the `settingsDefaults` object:
+
+```js
+var settingsDefaults = {
+  wpm: 250,
+  font: 'system',
+  theme: 'system',
+  fontSize: 42,
+  punctuationPause: true,
+  alignment: 'orp',
+  chunkSize: 1,
+};
+```
+
+- [ ] **Step 2: Add chunkSize to test query hook**
+
+In the `speedreader-test-query` handler, add after the `result.alignment` line:
+
+```js
+result.chunkSize = overlay.state.chunkSize || 1;
+```
+
+- [ ] **Step 3: Add set-chunk-size dispatch action**
+
+In the `speedreader-test-dispatch` handler, add `'set-chunk-size'` to the `overlayActions` array:
+
+```js
+var overlayActions = ['set-theme', 'set-font', 'set-wpm', 'set-font-size', 'set-alignment', 'set-chunk-size'];
+```
+
+Add the handler:
+
+```js
+} else if (action === 'set-chunk-size') {
+  overlay.updateSettings({ chunkSize: payload.chunkSize });
+}
+```
+
+- [ ] **Step 4: Lint**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add SpeedReader/SpeedReaderExtension/Resources/content.js
+git commit -m "Add chunkSize to content script settings defaults and test hooks (#18)"
+```
+
+---
+
+### Task 8: Swift — SettingsKeys and Settings model
+
+**Files:**
+- Modify: `SpeedReader/Shared/SettingsKeys.swift`
+- Modify: `SpeedReader/SpeedReader/Models/Settings.swift`
+
+- [ ] **Step 1: Add chunkSize to SettingsKeys**
+
+In `SettingsKeys.swift`, add the key after `alignment`:
+
+```swift
+static let chunkSize = "sr_chunkSize"
+```
+
+Add default:
+
+```swift
+enum Defaults {
+    // ... existing defaults ...
+    static let chunkSize = 1
+}
+```
+
+Add bounds:
+
+```swift
+static let chunkSizeMin = 1
+static let chunkSizeMax = 3
+```
+
+Add to `saveSettings()`, after the `alignment` block:
+
+```swift
+if let chunkSize = settings["chunkSize"] as? Int {
+    defaults.set(clamp(chunkSize, min: chunkSizeMin, max: chunkSizeMax), forKey: SettingsKeys.chunkSize)
+    savedCount += 1
+}
+```
+
+- [ ] **Step 2: Add chunkSize to ReaderSettings model**
+
+In `Settings.swift`, add the property:
+
+```swift
+var chunkSize: Int = SettingsKeys.Defaults.chunkSize
+```
+
+Add the setter after `setAlignment()`:
+
+```swift
+func setChunkSize(_ value: Int) {
+    chunkSize = SettingsKeys.clamp(value, min: SettingsKeys.chunkSizeMin, max: SettingsKeys.chunkSizeMax)
+    defaults.set(chunkSize, forKey: SettingsKeys.chunkSize)
+}
+```
+
+Add to `loadFromDefaults()`, after the alignment loading:
+
+```swift
+let loadedChunkSize = store.object(forKey: SettingsKeys.chunkSize) as? Int
+    ?? SettingsKeys.Defaults.chunkSize
+chunkSize = SettingsKeys.clamp(
+    loadedChunkSize, min: SettingsKeys.chunkSizeMin, max: SettingsKeys.chunkSizeMax
+)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add SpeedReader/Shared/SettingsKeys.swift SpeedReader/SpeedReader/Models/Settings.swift
+git commit -m "Add chunkSize to Swift settings infrastructure (#18)"
+```
+
+---
+
+### Task 9: SwiftUI — segmented control in SettingsView
+
+**Files:**
+- Modify: `SpeedReader/SpeedReader/Views/SettingsView.swift`
+
+- [ ] **Step 1: Add "Words per flash" segmented control**
+
+In `SettingsView.swift`, in the "Reading Speed" section, add after the punctuation pause toggle and before the section's closing brace:
+
+```swift
+Picker("Words per flash", selection: Binding(
+    get: { settings.chunkSize },
+    set: { settings.setChunkSize($0) }
+)) {
+    Text("1").tag(1)
+    Text("2").tag(2)
+    Text("3").tag(3)
+}
+.pickerStyle(.segmented)
+```
+
+- [ ] **Step 2: Update RSVPPreview to reflect chunk mode**
+
+The preview should show plain text (no ORP highlight) when chunk size > 1. Update the `RSVPPreview` struct to accept `chunkSize` and conditionally render:
+
+Add `let chunkSize: Int` to the struct properties.
+
+Update the `body` computed property — when `chunkSize > 1`, show a multi-word plain text preview instead of ORP-highlighted single word:
+
+```swift
+var body: some View {
+    Group {
+        if chunkSize > 1 {
+            Text("the quick brown")
+                .foregroundColor(textColor)
+                .font(font.font(size: CGFloat(fontSize)))
+                .lineLimit(1)
+                .minimumScaleFactor(0.3)
+                .frame(maxWidth: .infinity)
+        } else {
+            wordText
+                .font(font.font(size: CGFloat(fontSize)))
+                .lineLimit(1)
+                .minimumScaleFactor(0.3)
+                .frame(maxWidth: .infinity)
+        }
+    }
+    .padding(.vertical, 24)
+    .background(backgroundColor)
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+}
+```
+
+Update the call site in `SettingsView` to pass `chunkSize`:
+
+```swift
+RSVPPreview(
+    font: settings.font,
+    fontSize: settings.fontSize,
+    theme: settings.theme,
+    alignment: settings.alignment,
+    chunkSize: settings.chunkSize
+)
+```
+
+- [ ] **Step 3: Build the Swift project**
+
+Run: `make test-swift`
+Expected: Build and tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add SpeedReader/SpeedReader/Views/SettingsView.swift
+git commit -m "Add Words per flash segmented control to settings UI (#18)"
+```
+
+---
+
+### Task 10: Final verification
+
+- [ ] **Step 1: Run full JS test suite**
+
+Run: `make test-js`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run linting**
+
+Run: `make lint-js`
+Expected: No errors
+
+- [ ] **Step 3: Run Swift tests**
+
+Run: `make test-swift`
+Expected: All tests PASS
+
+- [ ] **Step 4: Run full CI**
+
+Run: `make ci`
+Expected: All tests and linting pass
+
+- [ ] **Step 5: Review git log**
+
+Run: `git log --oneline -10`
+
+Expected commits (newest first):
+```
+Add Words per flash segmented control to settings UI (#18)
+Add chunkSize to Swift settings infrastructure (#18)
+Add chunkSize to content script settings defaults and test hooks (#18)
+Add one-time tip banner for chunk size feature discovery (#18)
+Add dual render path for ORP and chunk display modes (#18)
+Register chunk-builder.js in manifest web_accessible_resources (#18)
+Integrate chunk-builder into state machine with proportional delay (#18)
+Add chunk-builder module with sentence-boundary-aware grouping (#18)
+Add chunkSize settings constants and clampChunkSize validator (#18)
+```

--- a/docs/superpowers/specs/2026-04-06-chunk-size-design.md
+++ b/docs/superpowers/specs/2026-04-06-chunk-size-design.md
@@ -1,0 +1,221 @@
+# Configurable Chunk Size — Design Spec
+
+**Issue:** #18 — Configurable chunk size (1, 2, or 3 words at a time)
+**Date:** 2026-04-06
+
+## Problem Statement
+
+**User**: Neurodivergent readers (ADHD, dyslexia) using SpeedReader's RSVP mode on iOS/iPadOS/macOS Safari.
+
+**Problem**: SpeedReader presents text one word at a time with no option to adjust chunk size. For readers who process phrase-level units more naturally — or who find single-word flashing at higher speeds overwhelming — the fixed single-word presentation reduces comprehension and comfort, with no way to adapt.
+
+**Impact**: Comprehension drops sharply above 300 WPM with single-word RSVP (Castelhano & Muter, Öquist & Lundin). Users who don't click with single-word mode have no fallback — they either tolerate a suboptimal experience or stop using the app entirely.
+
+**Evidence**: Academic research (Castelhano & Muter 2001, Öquist & Lundin 2007, Benedetto et al. 2015, Schneps et al. 2013) consistently supports 2-3 word chunks for improved comprehension. Competitor apps (Spreeder, SwiftRead, Reedy, AccelaReader, Jetzt) all offer this feature — it is table stakes on desktop/Android but largely absent on iOS.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| WPM semantics | Word rate stays constant | 250 WPM always means 250 individual words/min. A 2-word chunk displays for 2x base delay. Chunks affect comfort, not speed. Matches Spreeder/SwiftRead behavior. |
+| Sentence boundaries | Chunks break at sentence ends | Never cross `.!?` boundary in a single chunk. Preserves sentence-level comprehension. Leverages existing `sentenceStart` markers in word-processor output. |
+| ORP highlighting | Active in 1-word mode only; disabled (plain text) in chunk mode | Eye-tracking research (Inhoff & Rayner 1986, Drieghe et al. 2005) shows readers process 2-3 word phrases as perceptual units, not word-by-word. Per-word ORP adds visual noise without cognitive benefit. All competitor apps disable ORP in multi-word mode. |
+| Default chunk size | 1 word | Preserves current experience. New feature is opt-in. |
+| First-use tip | One-time dismissible banner | Points users to "Words per flash" setting. Dismissed on tap or first play. Stored in `browser.storage.sync`. |
+| Settings UI | Segmented control: `1 \| 2 \| 3` | Standard iOS pattern for small fixed sets. Labeled "Words per flash". |
+| Architecture | Dedicated `chunk-builder.js` module | Single responsibility — separates content shaping from playback control. Pure function, independently testable. State machine consumes chunks, not raw words. |
+
+## Architecture
+
+### Module Pipeline
+
+```
+processText(text) → words[]
+       ↓
+buildChunks(words, chunkSize) → chunks[]
+       ↓
+RSVPStateMachine (ticks through chunks)
+       ↓
+RSVPOverlay (renders ORP or plain text based on chunk mode)
+```
+
+### New Module: `chunk-builder.js`
+
+Pure-function module between word-processor and state machine.
+
+**Interface:**
+
+```js
+buildChunks(words, chunkSize) → chunk[]
+```
+
+- `words`: array from `processText()` — `[{text, index, sentenceStart}, ...]`
+- `chunkSize`: 1, 2, or 3
+- Returns: array of chunk objects
+
+**Chunk object shape:**
+
+```js
+{
+  words: [{text, index, sentenceStart}, ...],  // 1 to chunkSize word objects
+  startIndex: 0,     // index of first word in original words array
+  endIndex: 2,       // index of last word (inclusive)
+  text: "the beautiful sunset"  // pre-joined display string
+}
+```
+
+**Rules:**
+- Each chunk contains up to `chunkSize` words
+- Chunks never cross sentence boundaries (if `words[i+1].sentenceStart`, end chunk at `words[i]`)
+- Final chunk may be shorter than `chunkSize`
+- When `chunkSize` is 1, output is 1:1 with input (backward compatible)
+
+### State Machine Changes
+
+**New properties:**
+- `chunkSize` — from settings, default 1
+- `chunks` — array from `buildChunks()`
+- `chunkIndex` — current position in chunk array
+
+**`init(text, settings)`:**
+- Calls `processText(text)` as before (stores as `this.words`)
+- Calls `buildChunks(this.words, this.chunkSize)` (stores as `this.chunks`)
+
+**`tick()`:**
+- Advances `chunkIndex` by 1
+- Delay: `baseDelay * chunk.words.length` — proportional to word count in chunk (constant WPM)
+- Punctuation pause applies to **last word** in chunk only
+
+**`currentDisplay()`** (replaces `currentWord()`):
+
+- `chunkSize === 1`: returns `{before, focus, after, isChunk: false}` — ORP active
+- `chunkSize > 1`: returns `{text: chunk.text, isChunk: true}` — plain text
+- Overlay switches rendering path based on `isChunk`
+
+**Sentence navigation:**
+- `prevSentence()`/`nextSentence()` find the chunk whose first word has `sentenceStart === true`
+
+**`seekTo(wordIndex)`:**
+- Accepts word-level index (scrubber operates in word-space)
+- Maps to the chunk containing that word index
+
+**`progress()`, `timeElapsed()`, `timeRemaining()`:**
+- Computed from word-level position (`chunk.startIndex` mapped to word count)
+- WPM math unchanged
+
+**`contextSentence()`:**
+- Returns `highlightRange: {start, end}` instead of single `highlightIndex` for multi-word chunks
+
+**Backward compatibility invariant:** When `chunkSize === 1`, every chunk has one word, `chunkIndex` tracks the same position as `currentIndex` did, and `currentDisplay()` returns ORP-split output. Behavior is identical to current code.
+
+### Overlay Rendering Changes
+
+**Dual rendering path in `_renderDisplay()`:**
+
+- `isChunk === true`: Hide ORP spans (`wordBefore`, `wordFocus`, `wordAfter`). Show new `<span class="sr-chunk-text">` with plain text.
+- `isChunk === false`: Hide chunk span. Show ORP spans as before.
+
+**New DOM element:** `<span class="sr-chunk-text">` inside `wordContainer`. Styled to match existing word color (no accent highlight). Hidden when `chunkSize === 1`.
+
+**Context preview (`_showContext()`):**
+- Multi-word chunks: highlights all words in the current chunk range
+- Uses `highlightRange` from `contextSentence()` to wrap range in highlight spans
+
+**Scrubber:** Unchanged — still operates in word-space (0 to `words.length - 1`). `seekTo()` maps to chunks internally.
+
+**`_scaleWordToFit()`:** No change needed — already handles overflow by measuring `scrollWidth` vs container width. Multi-word chunks are wider, so scaling kicks in more often naturally.
+
+**Alignment:** ORP alignment mode (`data-alignment="orp"`) only applies when `chunkSize === 1`. When `isChunk` is true, overlay renders centered regardless of alignment setting. No new setting needed.
+
+### Settings Infrastructure
+
+**JS — `settings-defaults.js`:**
+
+```js
+export const CHUNK_SIZE_DEFAULT = 1;
+export const CHUNK_SIZE_MIN = 1;
+export const CHUNK_SIZE_MAX = 3;
+```
+
+Add `'chunkSize'` to `SETTINGS_KEYS` and `SETTINGS_DEFAULTS`. Add `clampChunkSize()` validator.
+
+**Swift — `SettingsKeys.swift`:**
+
+- Key: `static let chunkSize = "sr_chunkSize"`
+- Default: `static let chunkSize = 1`
+- Bounds: `chunkSizeMin = 1`, `chunkSizeMax = 3`
+- Add to `saveSettings()` with `Int` type check and clamping
+
+**Settings UI (Swift companion app):**
+
+- Segmented control labeled "Words per flash" with segments `1 | 2 | 3`
+- Placed below Speed (WPM) control, above Text Size
+- Bound to `chunkSize` in UserDefaults via App Group
+
+**Live update:** `overlay.updateSettings()` accepts `chunkSize`. If changed mid-session, state machine rebuilds chunks from the same word array, maps current word position to nearest chunk, and pauses. User resumes manually.
+
+### One-Time Tip
+
+**Trigger:** First overlay open after feature ships.
+
+**Storage:** `sr_chunkSizeTipSeen` boolean in `browser.storage.sync` (JS-side only, not in App Group).
+
+**Display:** Dismissible banner below word area, above controls:
+
+```
+ Tip: Try reading 2-3 words at a time.
+ Change "Words per flash" in Settings.
+                                [Got it]
+```
+
+- Appears in paused state before first play
+- Dismisses on "Got it" tap or when playback starts
+- Sets flag to `true` on dismiss — never shows again
+- Styled in shadow DOM, respects current theme
+
+## Edge Cases
+
+**Short text (fewer words than chunk size):** `buildChunks()` returns whatever words exist. No padding, no error.
+
+**Empty text:** `buildChunks([])` returns `[]`. State machine handles identically to empty words.
+
+**Chunk size changed mid-session:** Rebuild chunks, map position, pause. User resumes.
+
+**Sentence boundary at position 1 of a would-be chunk:** Chunk ends at word before boundary (may produce 1-word chunk). Next chunk starts the new sentence.
+
+**Reading position save/restore:** Positions saved as word-level indices. Valid regardless of chunk size changes between sessions. `seekTo()` maps word index to chunk.
+
+**Alignment interaction:** ORP alignment applies only when `chunkSize === 1`. Chunk mode always centers. No new setting.
+
+## Testing Strategy
+
+### New: `chunk-builder.test.js`
+- Chunks words correctly for sizes 1, 2, 3
+- Respects sentence boundaries (never crosses `.!?`)
+- Handles short final chunks
+- Empty input returns empty array
+- Single-word input with any chunk size
+- Chunk `text` field correctly joined with spaces
+
+### Additions to `state-machine.test.js`
+- `chunkSize=1` identical to current behavior (backward compat)
+- `tick()` with `chunkSize=2` returns delay = `baseDelay * 2`
+- Punctuation pause applies to last word in chunk only
+- `prevSentence()`/`nextSentence()` navigate by chunk boundaries
+- `seekTo(wordIndex)` maps correctly to chunk position
+- `currentDisplay()` returns `isChunk: true` with plain text for chunk sizes > 1
+- `currentDisplay()` returns ORP split for chunk size 1
+- `contextSentence()` returns highlight range for multi-word chunks
+- Progress/time calculations still word-based
+
+### Overlay regression tests
+- Chunk text element visible when `chunkSize > 1`, hidden when 1
+- ORP spans visible when `chunkSize === 1`, hidden when > 1
+- Tip banner shows on first open, dismissed on tap, never shows again
+- Alignment falls back to center in chunk mode
+- Scrubber operates in word-space
+
+### Settings tests
+- `clampChunkSize()` clamps to 1-3 range
+- Invalid input (string, NaN, 0, 4) falls back to default
+- Swift `saveSettings()` persists and clamps chunk size

--- a/tests/js/chunk-builder.test.js
+++ b/tests/js/chunk-builder.test.js
@@ -1,0 +1,116 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildChunks } from '../../SpeedReader/SpeedReaderExtension/Resources/rsvp/chunk-builder.js';
+
+describe('buildChunks', () => {
+
+  // Helper: create word objects matching processText() output shape
+  function words(texts) {
+    let nextIsSentenceStart = true;
+    return texts.map((text, index) => {
+      const entry = { text, index, sentenceStart: nextIsSentenceStart };
+      nextIsSentenceStart = /[.!?]$/.test(text);
+      return entry;
+    });
+  }
+
+  describe('chunkSize = 1', () => {
+    it('produces one chunk per word', () => {
+      const w = words(['Hello', 'world.']);
+      const chunks = buildChunks(w, 1);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'Hello');
+      assert.strictEqual(chunks[0].startIndex, 0);
+      assert.strictEqual(chunks[0].endIndex, 0);
+      assert.strictEqual(chunks[1].text, 'world.');
+      assert.strictEqual(chunks[1].startIndex, 1);
+      assert.strictEqual(chunks[1].endIndex, 1);
+    });
+  });
+
+  describe('chunkSize = 2', () => {
+    it('groups words into pairs', () => {
+      const w = words(['The', 'quick', 'brown', 'fox.']);
+      const chunks = buildChunks(w, 2);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'The quick');
+      assert.strictEqual(chunks[0].startIndex, 0);
+      assert.strictEqual(chunks[0].endIndex, 1);
+      assert.strictEqual(chunks[1].text, 'brown fox.');
+      assert.strictEqual(chunks[1].startIndex, 2);
+      assert.strictEqual(chunks[1].endIndex, 3);
+    });
+
+    it('handles odd word count with shorter final chunk', () => {
+      const w = words(['One', 'two', 'three.']);
+      const chunks = buildChunks(w, 2);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'One two');
+      assert.strictEqual(chunks[1].text, 'three.');
+      assert.strictEqual(chunks[1].words.length, 1);
+    });
+  });
+
+  describe('chunkSize = 3', () => {
+    it('groups words into triples', () => {
+      const w = words(['The', 'quick', 'brown', 'fox', 'jumps', 'over.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'The quick brown');
+      assert.strictEqual(chunks[1].text, 'fox jumps over.');
+    });
+  });
+
+  describe('sentence boundaries', () => {
+    it('breaks chunk at sentence boundary', () => {
+      const w = words(['Hello', 'world.', 'Goodbye', 'world.']);
+      const chunks = buildChunks(w, 3);
+      // "Hello world." is one chunk (2 words, shorter than 3 because sentence ends)
+      // "Goodbye world." is another chunk
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'Hello world.');
+      assert.strictEqual(chunks[0].words.length, 2);
+      assert.strictEqual(chunks[1].text, 'Goodbye world.');
+      assert.strictEqual(chunks[1].words.length, 2);
+    });
+
+    it('produces single-word chunk when sentence is one word', () => {
+      const w = words(['Stop.', 'Go.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'Stop.');
+      assert.strictEqual(chunks[1].text, 'Go.');
+    });
+
+    it('handles sentence boundary at position 2 of a 3-word chunk', () => {
+      // "A B. C D E." — chunk size 3
+      // Chunk 1: "A B." (sentence ends at B)
+      // Chunk 2: "C D E."
+      const w = words(['A', 'B.', 'C', 'D', 'E.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 2);
+      assert.strictEqual(chunks[0].text, 'A B.');
+      assert.strictEqual(chunks[1].text, 'C D E.');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input', () => {
+      assert.deepStrictEqual(buildChunks([], 2), []);
+    });
+
+    it('handles single word', () => {
+      const w = words(['Hello.']);
+      const chunks = buildChunks(w, 3);
+      assert.strictEqual(chunks.length, 1);
+      assert.strictEqual(chunks[0].text, 'Hello.');
+    });
+
+    it('chunk words array contains references to original word objects', () => {
+      const w = words(['The', 'cat.']);
+      const chunks = buildChunks(w, 2);
+      assert.strictEqual(chunks[0].words[0], w[0]);
+      assert.strictEqual(chunks[0].words[1], w[1]);
+    });
+  });
+});

--- a/tests/js/settings-defaults.test.js
+++ b/tests/js/settings-defaults.test.js
@@ -110,4 +110,10 @@ describe('clampChunkSize', () => {
     assert.strictEqual(clampChunkSize(CHUNK_SIZE_MIN), CHUNK_SIZE_MIN);
     assert.strictEqual(clampChunkSize(CHUNK_SIZE_MAX), CHUNK_SIZE_MAX);
   });
+
+  it('rounds floats to nearest integer', () => {
+    assert.strictEqual(clampChunkSize(1.5), 2);
+    assert.strictEqual(clampChunkSize(2.7), 3);
+    assert.strictEqual(clampChunkSize(0.6), 1);
+  });
 });

--- a/tests/js/settings-defaults.test.js
+++ b/tests/js/settings-defaults.test.js
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   clampFontSize, FONT_SIZE_DEFAULT, FONT_SIZE_MIN, FONT_SIZE_MAX,
+  clampChunkSize, CHUNK_SIZE_DEFAULT, CHUNK_SIZE_MIN, CHUNK_SIZE_MAX,
   SETTINGS_KEYS, SETTINGS_DEFAULTS,
   ALIGNMENT_DEFAULT, VALID_ALIGNMENTS, validateAlignment,
 } from '../../SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js';
@@ -85,5 +86,28 @@ describe('validateAlignment', () => {
     assert.ok(VALID_ALIGNMENTS.includes('orp'));
     assert.ok(VALID_ALIGNMENTS.includes('center'));
     assert.strictEqual(VALID_ALIGNMENTS.length, 2);
+  });
+});
+
+describe('clampChunkSize', () => {
+  it('returns default for non-number input', () => {
+    assert.strictEqual(clampChunkSize('two'), CHUNK_SIZE_DEFAULT);
+    assert.strictEqual(clampChunkSize(NaN), CHUNK_SIZE_DEFAULT);
+    assert.strictEqual(clampChunkSize(undefined), CHUNK_SIZE_DEFAULT);
+  });
+
+  it('clamps below minimum to minimum', () => {
+    assert.strictEqual(clampChunkSize(0), CHUNK_SIZE_MIN);
+    assert.strictEqual(clampChunkSize(-1), CHUNK_SIZE_MIN);
+  });
+
+  it('clamps above maximum to maximum', () => {
+    assert.strictEqual(clampChunkSize(4), CHUNK_SIZE_MAX);
+    assert.strictEqual(clampChunkSize(99), CHUNK_SIZE_MAX);
+  });
+
+  it('accepts boundary values', () => {
+    assert.strictEqual(clampChunkSize(CHUNK_SIZE_MIN), CHUNK_SIZE_MIN);
+    assert.strictEqual(clampChunkSize(CHUNK_SIZE_MAX), CHUNK_SIZE_MAX);
   });
 });

--- a/tests/js/state-machine.test.js
+++ b/tests/js/state-machine.test.js
@@ -46,7 +46,7 @@ describe('RSVPStateMachine', () => {
     it('resets state on re-init', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three.');
-      sm.currentIndex = 2;
+      sm.chunkIndex = 2;
       sm.isPlaying = true;
       sm.init('New text here.');
       assert.strictEqual(sm.currentIndex, 0);
@@ -66,7 +66,7 @@ describe('RSVPStateMachine', () => {
     it('resets index to 0 when at end of text', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world.');
-      sm.currentIndex = sm.words.length;
+      sm.chunkIndex = sm.chunks.length;
       sm.play();
       assert.strictEqual(sm.currentIndex, 0);
       assert.strictEqual(sm.isPlaying, true);
@@ -75,7 +75,7 @@ describe('RSVPStateMachine', () => {
     it('does not reset index when in the middle of text', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world again.');
-      sm.currentIndex = 1;
+      sm.chunkIndex = 1;
       sm.play();
       assert.strictEqual(sm.currentIndex, 1);
     });
@@ -130,7 +130,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world.', { wpm: 250, punctuationPause: true });
       sm.play();
-      sm.currentIndex = 1;
+      sm.chunkIndex = 1;
       const result = sm.tick();
       assert.strictEqual(result.delay, Math.round(240 * 1.5));
     });
@@ -139,7 +139,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world.', { wpm: 250, punctuationPause: false });
       sm.play();
-      sm.currentIndex = 1;
+      sm.chunkIndex = 1;
       const result = sm.tick();
       assert.strictEqual(result.delay, 240);
     });
@@ -148,7 +148,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world.');
       sm.play();
-      sm.currentIndex = sm.words.length - 1;
+      sm.chunkIndex = sm.chunks.length - 1;
       const result = sm.tick();
       assert.strictEqual(result.done, true);
       assert.strictEqual(sm.isPlaying, false);
@@ -158,7 +158,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world.', { wpm: 250 });
       sm.play();
-      sm.currentIndex = sm.words.length - 1; // "world."
+      sm.chunkIndex = sm.chunks.length - 1; // "world."
       const result = sm.tick();
       assert.strictEqual(result.done, true);
       assert.strictEqual(result.delay, Math.round(240 * 1.5)); // period = 1.5x
@@ -177,7 +177,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
       sm.play();
-      sm.currentIndex = 3; // "sentence." is index 3
+      sm.chunkIndex = 3; // "sentence." is index 3
       sm.prevSentence();
       assert.strictEqual(sm.currentIndex, 2); // "Second" — start of 2nd sentence
       assert.strictEqual(sm.isPlaying, false);
@@ -187,7 +187,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
       sm.play();
-      sm.currentIndex = 2; // "Second" — already at sentence start
+      sm.chunkIndex = 2; // "Second" — already at sentence start
       sm.prevSentence();
       assert.strictEqual(sm.currentIndex, 0); // "First" — start of 1st sentence
     });
@@ -196,7 +196,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
       sm.play();
-      sm.currentIndex = 0;
+      sm.chunkIndex = 0;
       sm.prevSentence();
       assert.strictEqual(sm.currentIndex, 0);
     });
@@ -205,7 +205,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
       sm.play();
-      sm.currentIndex = 3;
+      sm.chunkIndex = 3;
       sm.prevSentence();
       assert.strictEqual(sm.isPlaying, false);
     });
@@ -216,7 +216,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
       sm.play();
-      sm.currentIndex = 0;
+      sm.chunkIndex = 0;
       sm.nextSentence();
       assert.strictEqual(sm.currentIndex, 2); // "Second"
       assert.strictEqual(sm.isPlaying, false);
@@ -226,7 +226,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
       sm.play();
-      sm.currentIndex = 2; // "Second" — start of last sentence
+      sm.chunkIndex = 2; // "Second" — start of last sentence
       sm.nextSentence();
       assert.strictEqual(sm.currentIndex, 2); // no next sentence, stays
     });
@@ -235,7 +235,7 @@ describe('RSVPStateMachine', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
       sm.play();
-      sm.currentIndex = 0;
+      sm.chunkIndex = 0;
       sm.nextSentence();
       assert.strictEqual(sm.isPlaying, false);
     });
@@ -277,7 +277,7 @@ describe('RSVPStateMachine', () => {
     it('returns split word at current index', () => {
       const sm = new RSVPStateMachine();
       sm.init('Reading is fun.');
-      sm.currentIndex = 0;
+      sm.chunkIndex = 0;
       const word = sm.currentWord();
       // "Reading" — ORP at floor(7*0.3) = index 2 → "Re" + "a" + "ding"
       assert.strictEqual(word.before, 'Re');
@@ -288,7 +288,7 @@ describe('RSVPStateMachine', () => {
     it('returns empty parts when past end', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello.');
-      sm.currentIndex = sm.words.length;
+      sm.chunkIndex = sm.chunks.length;
       const word = sm.currentWord();
       assert.strictEqual(word.before, '');
       assert.strictEqual(word.focus, '');
@@ -309,7 +309,7 @@ describe('RSVPStateMachine', () => {
     it('returns 50% at midpoint', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three four.');
-      sm.currentIndex = 2;
+      sm.chunkIndex = 2;
       const p = sm.progress();
       assert.strictEqual(p.percent, 50);
       assert.strictEqual(p.current, 2);
@@ -319,7 +319,7 @@ describe('RSVPStateMachine', () => {
     it('returns 100% at end', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three four.');
-      sm.currentIndex = 4;
+      sm.chunkIndex = sm.chunks.length;
       const p = sm.progress();
       assert.strictEqual(p.percent, 100);
     });
@@ -388,7 +388,7 @@ describe('RSVPStateMachine', () => {
     it('ignores NaN index without corrupting state', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three.');
-      sm.currentIndex = 1;
+      sm.chunkIndex = 1;
       sm.seekTo(NaN);
       assert.strictEqual(sm.currentIndex, 1); // unchanged
     });
@@ -396,7 +396,7 @@ describe('RSVPStateMachine', () => {
     it('ignores non-integer index', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three.');
-      sm.currentIndex = 1;
+      sm.chunkIndex = 1;
       sm.seekTo(1.5);
       assert.strictEqual(sm.currentIndex, 1); // unchanged
     });
@@ -421,7 +421,7 @@ describe('RSVPStateMachine', () => {
     it('returns correct times at midpoint', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three four five six.', { wpm: 300 }); // 6 words at 300wpm
-      sm.currentIndex = 3; // halfway
+      sm.chunkIndex = 3; // halfway
       // elapsed: ceil(3 / 300 * 60) = ceil(0.6) = 1
       assert.strictEqual(sm.timeElapsed(), 1);
       // remaining: ceil(3 / 300 * 60) = ceil(0.6) = 1
@@ -431,7 +431,7 @@ describe('RSVPStateMachine', () => {
     it('returns full elapsed and 0 remaining at end', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three four.', { wpm: 240 });
-      sm.currentIndex = 4; // past last word
+      sm.chunkIndex = sm.chunks.length; // past last word
       assert.strictEqual(sm.timeRemaining(), 0);
       assert.strictEqual(sm.timeElapsed(), 1);
     });
@@ -449,7 +449,7 @@ describe('RSVPStateMachine', () => {
     it('timeRemaining reaches 0 at end and timeElapsed equals total duration', () => {
       const sm = new RSVPStateMachine();
       sm.init('One two three four.', { wpm: 240 }); // 4 words at 240wpm = 1 sec
-      sm.currentIndex = sm.words.length;
+      sm.chunkIndex = sm.chunks.length;
       assert.strictEqual(sm.timeRemaining(), 0);
       assert.strictEqual(sm.timeElapsed(), Math.ceil((sm.words.length / sm.wpm) * 60));
     });
@@ -466,7 +466,7 @@ describe('RSVPStateMachine', () => {
     it('returns words in current sentence with highlight index', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
-      sm.currentIndex = 3; // "sentence." in 2nd sentence
+      sm.chunkIndex = 3; // "sentence." in 2nd sentence
       const ctx = sm.contextSentence();
       assert.deepStrictEqual(ctx.words, ['Second', 'sentence.']);
       assert.strictEqual(ctx.highlightIndex, 1);
@@ -475,7 +475,7 @@ describe('RSVPStateMachine', () => {
     it('returns first sentence when at start', () => {
       const sm = new RSVPStateMachine();
       sm.init('First sentence. Second sentence.');
-      sm.currentIndex = 0;
+      sm.chunkIndex = 0;
       const ctx = sm.contextSentence();
       assert.deepStrictEqual(ctx.words, ['First', 'sentence.']);
       assert.strictEqual(ctx.highlightIndex, 0);
@@ -484,11 +484,204 @@ describe('RSVPStateMachine', () => {
     it('returns empty for index past end', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world.');
-      sm.currentIndex = sm.words.length;
+      sm.chunkIndex = sm.chunks.length;
       const ctx = sm.contextSentence();
       assert.deepStrictEqual(ctx.words, []);
       assert.strictEqual(ctx.highlightIndex, -1);
     });
   });
 
+});
+
+describe('chunk mode (chunkSize > 1)', () => {
+
+  describe('init with chunkSize', () => {
+    it('builds chunks from words', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { chunkSize: 2 });
+      assert.strictEqual(sm.chunks.length, 2); // "The quick" + "brown fox."
+      assert.strictEqual(sm.chunkIndex, 0);
+    });
+
+    it('defaults to chunkSize 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.');
+      assert.strictEqual(sm.chunkSize, 1);
+      assert.strictEqual(sm.chunks.length, 2); // one chunk per word
+    });
+  });
+
+  describe('tick with chunks', () => {
+    it('advances chunkIndex by 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { wpm: 250, chunkSize: 2 });
+      sm.play();
+      const result = sm.tick();
+      assert.strictEqual(sm.chunkIndex, 1);
+      assert.strictEqual(result.done, undefined);
+    });
+
+    it('returns delay proportional to words in chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { wpm: 250, chunkSize: 2 });
+      sm.play();
+      const result = sm.tick();
+      // 2-word chunk: baseDelay (240) * 2 = 480
+      assert.strictEqual(result.delay, 480);
+    });
+
+    it('applies punctuation pause to last word in chunk only', () => {
+      const sm = new RSVPStateMachine();
+      // "Hello world." is one 2-word chunk, last word has period
+      sm.init('Hello world.', { wpm: 250, chunkSize: 2, punctuationPause: true });
+      sm.play();
+      const result = sm.tick();
+      // baseDelay=240, 2 words=480, period on last word=480*1.5=720
+      assert.strictEqual(result.delay, Math.round(480 * 1.5));
+    });
+
+    it('returns done at last chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.', { chunkSize: 2 });
+      sm.play();
+      // Only one chunk: "Hello world."
+      const result = sm.tick();
+      assert.strictEqual(result.done, true);
+      assert.strictEqual(sm.isPlaying, false);
+    });
+  });
+
+  describe('currentDisplay', () => {
+    it('returns isChunk false with ORP split for chunkSize 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Reading.', { chunkSize: 1 });
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, false);
+      assert.strictEqual(typeof d.before, 'string');
+      assert.strictEqual(typeof d.focus, 'string');
+      assert.strictEqual(typeof d.after, 'string');
+    });
+
+    it('returns isChunk true with plain text for chunkSize 2', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.', { chunkSize: 2 });
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, true);
+      assert.strictEqual(d.text, 'Hello world.');
+    });
+
+    it('returns empty display past end', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hi.', { chunkSize: 2 });
+      sm.chunkIndex = sm.chunks.length;
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, false);
+      assert.strictEqual(d.before, '');
+      assert.strictEqual(d.focus, '');
+      assert.strictEqual(d.after, '');
+    });
+  });
+
+  describe('sentence navigation with chunks', () => {
+    it('prevSentence jumps to chunk containing previous sentence start', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('First sentence. Second sentence.', { chunkSize: 2 });
+      sm.play();
+      // chunks: ["First sentence."], ["Second sentence."]
+      sm.chunkIndex = 1;
+      sm.prevSentence();
+      assert.strictEqual(sm.chunkIndex, 0);
+    });
+
+    it('nextSentence jumps to chunk containing next sentence start', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('First sentence. Second sentence.', { chunkSize: 2 });
+      sm.play();
+      sm.chunkIndex = 0;
+      sm.nextSentence();
+      assert.strictEqual(sm.chunkIndex, 1);
+    });
+  });
+
+  describe('seekTo with chunks', () => {
+    it('maps word index to correct chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      // chunks: ["One two"], ["three four."]
+      sm.seekTo(2); // word "three" is in chunk 1
+      assert.strictEqual(sm.chunkIndex, 1);
+    });
+
+    it('maps word index 0 to chunk 0', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      sm.seekTo(0);
+      assert.strictEqual(sm.chunkIndex, 0);
+    });
+  });
+
+  describe('progress with chunks', () => {
+    it('reports word-level progress not chunk-level', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      sm.chunkIndex = 1; // chunk 1 starts at word index 2
+      const p = sm.progress();
+      assert.strictEqual(p.current, 2); // word index, not chunk index
+      assert.strictEqual(p.total, 4);
+      assert.strictEqual(p.percent, 50);
+    });
+  });
+
+  describe('timeElapsed and timeRemaining with chunks', () => {
+    it('computes from word position not chunk position', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { wpm: 240, chunkSize: 2 });
+      sm.chunkIndex = 1; // word index 2
+      // elapsed: ceil(2/240*60) = ceil(0.5) = 1
+      assert.strictEqual(sm.timeElapsed(), 1);
+      // remaining: ceil(2/240*60) = ceil(0.5) = 1
+      assert.strictEqual(sm.timeRemaining(), 1);
+    });
+  });
+
+  describe('contextSentence with chunks', () => {
+    it('returns highlightRange for multi-word chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('The quick brown fox.', { chunkSize: 2 });
+      // chunk 0: "The quick" (words 0-1), chunk 1: "brown fox." (words 2-3)
+      sm.chunkIndex = 0;
+      const ctx = sm.contextSentence();
+      assert.deepStrictEqual(ctx.highlightRange, { start: 0, end: 1 });
+    });
+
+    it('returns single highlightIndex for chunkSize 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world.', { chunkSize: 1 });
+      sm.chunkIndex = 0;
+      const ctx = sm.contextSentence();
+      assert.strictEqual(ctx.highlightIndex, 0);
+      assert.strictEqual(ctx.highlightRange, undefined);
+    });
+  });
+
+  describe('backward compatibility (chunkSize 1)', () => {
+    it('tick advances same as before', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Hello world again.', { wpm: 250, chunkSize: 1 });
+      sm.play();
+      const result = sm.tick();
+      assert.strictEqual(sm.chunkIndex, 1);
+      assert.strictEqual(result.delay, 240); // single word, baseDelay * 1
+    });
+
+    it('currentDisplay returns ORP split', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('Reading.', { chunkSize: 1 });
+      const d = sm.currentDisplay();
+      assert.strictEqual(d.isChunk, false);
+      assert.strictEqual(d.before, 'Re');
+      assert.strictEqual(d.focus, 'a');
+      assert.strictEqual(d.after, 'ding.');
+    });
+  });
 });

--- a/tests/js/state-machine.test.js
+++ b/tests/js/state-machine.test.js
@@ -540,6 +540,16 @@ describe('chunk mode (chunkSize > 1)', () => {
       assert.strictEqual(result.delay, Math.round(480 * 1.5));
     });
 
+    it('applies comma pause (1.2x) to last word in chunk', () => {
+      const sm = new RSVPStateMachine();
+      // "Hello world," is one 2-word chunk, last word has comma
+      sm.init('Hello world, goodbye.', { wpm: 250, chunkSize: 2, punctuationPause: true });
+      sm.play();
+      const result = sm.tick();
+      // baseDelay=240, 2 words=480, comma on last word=480*1.2=576
+      assert.strictEqual(result.delay, Math.round(480 * 1.2));
+    });
+
     it('returns done at last chunk', () => {
       const sm = new RSVPStateMachine();
       sm.init('Hello world.', { chunkSize: 2 });
@@ -661,6 +671,51 @@ describe('chunk mode (chunkSize > 1)', () => {
       const ctx = sm.contextSentence();
       assert.strictEqual(ctx.highlightIndex, 0);
       assert.strictEqual(ctx.highlightRange, undefined);
+    });
+  });
+
+  describe('rebuildChunks', () => {
+    it('preserves position when switching from size 1 to 2', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 1 });
+      sm.chunkIndex = 2; // word "three" at index 2
+      sm.rebuildChunks(2);
+      // chunks: ["One two"], ["three four."] — word 2 is in chunk 1
+      assert.strictEqual(sm.chunkSize, 2);
+      assert.strictEqual(sm.chunkIndex, 1);
+    });
+
+    it('preserves position when switching from size 2 to 1', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      sm.chunkIndex = 1; // chunk 1 = "three four." starts at word 2
+      sm.rebuildChunks(1);
+      // chunks: 4 single-word chunks — word 2 is chunk 2
+      assert.strictEqual(sm.chunkSize, 1);
+      assert.strictEqual(sm.chunkIndex, 2);
+    });
+
+    it('stays at 0 when at start', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 1 });
+      sm.chunkIndex = 0;
+      sm.rebuildChunks(3);
+      assert.strictEqual(sm.chunkIndex, 0);
+    });
+
+    it('stays near end when at last chunk', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three four.', { chunkSize: 2 });
+      sm.chunkIndex = 1; // last chunk, word index 2
+      sm.rebuildChunks(1);
+      assert.strictEqual(sm.chunkIndex, 2); // word 2 in single-word mode
+    });
+
+    it('clamps invalid chunk size', () => {
+      const sm = new RSVPStateMachine();
+      sm.init('One two three.', { chunkSize: 1 });
+      sm.rebuildChunks(99);
+      assert.strictEqual(sm.chunkSize, 3);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #18. Adds configurable chunk size to the RSVP reader, allowing users to display 1, 2, or 3 words at a time during playback.

- **New `chunk-builder.js` module** — pure function that groups words into display chunks, respecting sentence boundaries (never crosses `.!?`)
- **State machine refactor** — ticks through chunks with proportional delay (constant WPM), dual `currentDisplay()` output for ORP vs plain text modes
- **Overlay dual rendering** — ORP focus-point highlighting for single-word mode, plain text for chunk mode, alignment auto-falls back to centered in chunk mode
- **One-time tip banner** — dismissible "Try 2-3 words at a time" tip on first overlay open, stored in `browser.storage.sync`
- **Settings infrastructure** — JS constants + Swift SettingsKeys + "Words per flash" segmented control in companion app
- **193 tests pass** (30 new chunk-mode tests + 10 chunk-builder tests + 4 settings tests)

### Key design decisions

| Decision | Choice |
|---|---|
| WPM semantics | Word rate stays constant — 2-word chunks display for 2x base delay |
| Sentence boundaries | Chunks break at sentence ends — never cross `.!?` |
| ORP highlighting | Active in 1-word mode only; disabled in chunk mode (per eye-tracking research) |
| Architecture | Dedicated chunk-builder module (SRP) between word-processor and state machine |

### Design spec & plan
- [Design spec](docs/superpowers/specs/2026-04-06-chunk-size-design.md)
- [Implementation plan](docs/plans/2026-04-06-chunk-size.md)

## Test plan

- [x] `chunk-builder.test.js` — sentence boundary enforcement, edge cases, all chunk sizes
- [x] `state-machine.test.js` — chunk tick delay, navigation, seek, progress, backward compat
- [x] `settings-defaults.test.js` — `clampChunkSize()` validation
- [x] All 193 JS unit tests pass
- [x] ESLint clean
- [ ] Manual test: open overlay with chunkSize=1, verify ORP highlighting works as before
- [ ] Manual test: set chunkSize=2 in companion app, verify 2-word plain text display
- [ ] Manual test: verify tip banner shows once and dismisses on tap or play
- [ ] Manual test: verify scrubber and time estimates still work correctly with chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)