### PR TITLE
fix: stop auto-creating certificates on every deploy

### DIFF
--- a/SpeedReader/SpeedReader.xcodeproj/project.pbxproj
+++ b/SpeedReader/SpeedReader.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -705,7 +705,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chriscantu.SpeedReader;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -730,7 +730,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -751,7 +751,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chriscantu.SpeedReader;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -774,7 +774,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -790,7 +790,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -818,7 +818,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SpeedReaderExtension/Info.plist;
@@ -831,7 +831,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -858,7 +858,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chriscantu.SpeedReader.SpeedReaderTests;
@@ -876,7 +876,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chriscantu.SpeedReader.SpeedReaderTests;
@@ -894,7 +894,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -915,7 +915,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;

--- a/SpeedReader/SpeedReader.xcodeproj/project.pbxproj
+++ b/SpeedReader/SpeedReader.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -730,7 +730,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -774,7 +774,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -818,7 +818,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SpeedReaderExtension/Info.plist;
@@ -858,7 +858,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chriscantu.SpeedReader.SpeedReaderTests;
@@ -876,7 +876,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chriscantu.SpeedReader.SpeedReaderTests;
@@ -894,7 +894,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -915,7 +915,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4AKSB2RDBU;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,11 @@
 default_platform(:ios)
 
+APP_BUNDLE_ID = "com.chriscantu.SpeedReader"
+EXTENSION_BUNDLE_ID = "com.chriscantu.SpeedReader.SpeedReaderExtension"
+
 platform :ios do
   before_all do
-    @api_key = app_store_connect_api_key(
+    app_store_connect_api_key(
       key_id: ENV.fetch("APP_STORE_CONNECT_KEY_ID"),
       issuer_id: ENV.fetch("APP_STORE_CONNECT_ISSUER_ID"),
       key_content: ENV.fetch("APP_STORE_CONNECT_KEY"),
@@ -10,26 +13,47 @@ platform :ios do
     )
   end
 
+  # Download existing provisioning profiles without creating new certs or profiles.
+  # Uses the API key from lane_context (set in before_all).
+  private_lane :fetch_profiles do |options|
+    profiles = {}
+    [APP_BUNDLE_ID, EXTENSION_BUNDLE_ID].each do |bundle_id|
+      get_provisioning_profile(
+        app_identifier: bundle_id,
+        platform: options[:platform],
+        readonly: true
+      )
+      profiles[bundle_id] = lane_context[SharedValues::SIGH_NAME]
+    end
+    profiles
+  end
+
   desc "Build and upload to TestFlight (iOS + macOS)"
   lane :beta do
     setup_ci
 
+    ios_profiles = fetch_profiles(platform: "ios")
     build_app(
-      xcargs: auth_xcargs,
       destination: "generic/platform=iOS",
-      output_directory: "./build/ios"
+      output_directory: "./build/ios",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: ios_profiles
+      }
     )
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true
-    )
+    upload_to_testflight(skip_waiting_for_build_processing: true)
 
+    macos_profiles = fetch_profiles(platform: "macos")
     build_mac_app(
-      xcargs: auth_xcargs,
       scheme: "SpeedReader",
       project: "SpeedReader/SpeedReader.xcodeproj",
       output_directory: "./build/macos",
       export_method: "app-store",
-      clean: true
+      clean: true,
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: macos_profiles
+      }
     )
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
@@ -41,10 +65,14 @@ platform :ios do
   lane :release do
     setup_ci
 
+    ios_profiles = fetch_profiles(platform: "ios")
     build_app(
-      xcargs: auth_xcargs,
       destination: "generic/platform=iOS",
-      output_directory: "./build/ios"
+      output_directory: "./build/ios",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: ios_profiles
+      }
     )
     upload_to_app_store(
       submit_for_review: false,
@@ -54,13 +82,17 @@ platform :ios do
       precheck_include_in_app_purchases: false
     )
 
+    macos_profiles = fetch_profiles(platform: "macos")
     build_mac_app(
-      xcargs: auth_xcargs,
       scheme: "SpeedReader",
       project: "SpeedReader/SpeedReader.xcodeproj",
       output_directory: "./build/macos",
       export_method: "app-store",
-      clean: true
+      clean: true,
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: macos_profiles
+      }
     )
     upload_to_app_store(
       submit_for_review: false,
@@ -71,16 +103,4 @@ platform :ios do
       pkg: lane_context[SharedValues::PKG_OUTPUT_PATH]
     )
   end
-end
-
-def auth_xcargs
-  key_path = File.join(Dir.tmpdir, "AuthKey_#{ENV.fetch('APP_STORE_CONNECT_KEY_ID')}.p8")
-  unless File.exist?(key_path)
-    require "base64"
-    File.write(key_path, Base64.decode64(ENV.fetch("APP_STORE_CONNECT_KEY")))
-  end
-  "-authenticationKeyPath '#{key_path}' " \
-    "-authenticationKeyID '#{ENV.fetch('APP_STORE_CONNECT_KEY_ID')}' " \
-    "-authenticationKeyIssuerID '#{ENV.fetch('APP_STORE_CONNECT_ISSUER_ID')}' " \
-    "-allowProvisioningUpdates"
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,15 +13,16 @@ platform :ios do
     )
   end
 
-  # Download existing provisioning profiles without creating new certs or profiles.
-  # Uses the API key from lane_context (set in before_all).
+  # Fetch (or create) provisioning profiles via sigh.
+  # sigh manages profiles only — it never creates certificates.
+  # Certificate creation was the root cause of #55 and is prevented
+  # by removing -allowProvisioningUpdates from xcodebuild args.
   private_lane :fetch_profiles do |options|
     profiles = {}
     [APP_BUNDLE_ID, EXTENSION_BUNDLE_ID].each do |bundle_id|
       get_provisioning_profile(
         app_identifier: bundle_id,
-        platform: options[:platform],
-        readonly: true
+        platform: options[:platform]
       )
       profiles[bundle_id] = lane_context[SharedValues::SIGH_NAME]
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,11 +2,7 @@ default_platform(:ios)
 
 APP_BUNDLE_ID = "com.chriscantu.SpeedReader"
 EXTENSION_BUNDLE_ID = "com.chriscantu.SpeedReader.SpeedReaderExtension"
-
-# Override automatic signing at build time without modifying the project file.
-# Each xcodebuild invocation gets its own signing config — no cross-platform
-# contamination between iOS and macOS builds.
-SIGNING_XCARGS = "CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY='Apple Distribution'"
+XCODE_PROJECT = "SpeedReader/SpeedReader.xcodeproj"
 
 platform :ios do
   before_all do
@@ -34,13 +30,50 @@ platform :ios do
     profiles
   end
 
+  # Set platform-conditional signing in the Xcode project (CI checkout only).
+  # The project supports both iOS and macOS (SUPPORTED_PLATFORMS), so each
+  # target needs per-SDK profile specifiers to avoid cross-platform validation
+  # errors during archive.
+  private_lane :configure_signing do |options|
+    ios_profiles = options[:ios_profiles]
+    macos_profiles = options[:macos_profiles]
+
+    require "xcodeproj"
+    project = Xcodeproj::Project.open(XCODE_PROJECT)
+
+    target_bundle_ids = {
+      "SpeedReader" => APP_BUNDLE_ID,
+      "SpeedReaderExtension" => EXTENSION_BUNDLE_ID
+    }
+
+    project.targets.each do |target|
+      bundle_id = target_bundle_ids[target.name]
+      next unless bundle_id
+
+      target.build_configurations.each do |config|
+        s = config.build_settings
+        s["CODE_SIGN_STYLE"] = "Manual"
+        s["CODE_SIGN_IDENTITY"] = "Apple Distribution"
+        s["CODE_SIGN_IDENTITY[sdk=macosx*]"] = "Apple Distribution"
+        # Base value applies to iphoneos/iphonesimulator
+        s["PROVISIONING_PROFILE_SPECIFIER"] = ios_profiles[bundle_id]
+        # macOS override
+        s["PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]"] = macos_profiles[bundle_id]
+      end
+    end
+
+    project.save
+  end
+
   desc "Build and upload to TestFlight (iOS + macOS)"
   lane :beta do
     setup_ci
 
     ios_profiles = fetch_profiles(platform: "ios")
+    macos_profiles = fetch_profiles(platform: "macos")
+    configure_signing(ios_profiles: ios_profiles, macos_profiles: macos_profiles)
+
     build_app(
-      xcargs: SIGNING_XCARGS,
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
       export_options: {
@@ -50,11 +83,9 @@ platform :ios do
     )
     upload_to_testflight(skip_waiting_for_build_processing: true)
 
-    macos_profiles = fetch_profiles(platform: "macos")
     build_mac_app(
-      xcargs: SIGNING_XCARGS,
       scheme: "SpeedReader",
-      project: "SpeedReader/SpeedReader.xcodeproj",
+      project: XCODE_PROJECT,
       output_directory: "./build/macos",
       export_method: "app-store",
       clean: true,
@@ -74,8 +105,10 @@ platform :ios do
     setup_ci
 
     ios_profiles = fetch_profiles(platform: "ios")
+    macos_profiles = fetch_profiles(platform: "macos")
+    configure_signing(ios_profiles: ios_profiles, macos_profiles: macos_profiles)
+
     build_app(
-      xcargs: SIGNING_XCARGS,
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
       export_options: {
@@ -91,11 +124,9 @@ platform :ios do
       precheck_include_in_app_purchases: false
     )
 
-    macos_profiles = fetch_profiles(platform: "macos")
     build_mac_app(
-      xcargs: SIGNING_XCARGS,
       scheme: "SpeedReader",
-      project: "SpeedReader/SpeedReader.xcodeproj",
+      project: XCODE_PROJECT,
       output_directory: "./build/macos",
       export_method: "app-store",
       clean: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,10 @@ default_platform(:ios)
 
 APP_BUNDLE_ID = "com.chriscantu.SpeedReader"
 EXTENSION_BUNDLE_ID = "com.chriscantu.SpeedReader.SpeedReaderExtension"
+TARGETS = {
+  APP_BUNDLE_ID => "SpeedReader",
+  EXTENSION_BUNDLE_ID => "SpeedReaderExtension"
+}.freeze
 
 platform :ios do
   before_all do
@@ -29,11 +33,29 @@ platform :ios do
     profiles
   end
 
+  # Switch Xcode project to manual signing with distribution identity.
+  # Required because the project uses automatic signing locally, but on CI
+  # we can't pass -allowProvisioningUpdates (it creates certificates).
+  # This modifies the pbxproj on the disposable CI checkout only.
+  private_lane :apply_signing do |options|
+    profiles = options[:profiles]
+    profiles.each do |bundle_id, profile_name|
+      update_code_signing_settings(
+        path: "SpeedReader/SpeedReader.xcodeproj",
+        use_automatic_signing: false,
+        code_sign_identity: "Apple Distribution",
+        profile_name: profile_name,
+        targets: [TARGETS[bundle_id]]
+      )
+    end
+  end
+
   desc "Build and upload to TestFlight (iOS + macOS)"
   lane :beta do
     setup_ci
 
     ios_profiles = fetch_profiles(platform: "ios")
+    apply_signing(profiles: ios_profiles)
     build_app(
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
@@ -45,6 +67,7 @@ platform :ios do
     upload_to_testflight(skip_waiting_for_build_processing: true)
 
     macos_profiles = fetch_profiles(platform: "macos")
+    apply_signing(profiles: macos_profiles)
     build_mac_app(
       scheme: "SpeedReader",
       project: "SpeedReader/SpeedReader.xcodeproj",
@@ -67,6 +90,7 @@ platform :ios do
     setup_ci
 
     ios_profiles = fetch_profiles(platform: "ios")
+    apply_signing(profiles: ios_profiles)
     build_app(
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
@@ -84,6 +108,7 @@ platform :ios do
     )
 
     macos_profiles = fetch_profiles(platform: "macos")
+    apply_signing(profiles: macos_profiles)
     build_mac_app(
       scheme: "SpeedReader",
       project: "SpeedReader/SpeedReader.xcodeproj",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,10 +2,11 @@ default_platform(:ios)
 
 APP_BUNDLE_ID = "com.chriscantu.SpeedReader"
 EXTENSION_BUNDLE_ID = "com.chriscantu.SpeedReader.SpeedReaderExtension"
-TARGETS = {
-  APP_BUNDLE_ID => "SpeedReader",
-  EXTENSION_BUNDLE_ID => "SpeedReaderExtension"
-}.freeze
+
+# Override automatic signing at build time without modifying the project file.
+# Each xcodebuild invocation gets its own signing config — no cross-platform
+# contamination between iOS and macOS builds.
+SIGNING_XCARGS = "CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY='Apple Distribution'"
 
 platform :ios do
   before_all do
@@ -33,30 +34,13 @@ platform :ios do
     profiles
   end
 
-  # Switch Xcode project to manual signing with distribution identity.
-  # Required because the project uses automatic signing locally, but on CI
-  # we can't pass -allowProvisioningUpdates (it creates certificates).
-  # This modifies the pbxproj on the disposable CI checkout only.
-  private_lane :apply_signing do |options|
-    profiles = options[:profiles]
-    profiles.each do |bundle_id, profile_name|
-      update_code_signing_settings(
-        path: "SpeedReader/SpeedReader.xcodeproj",
-        use_automatic_signing: false,
-        code_sign_identity: "Apple Distribution",
-        profile_name: profile_name,
-        targets: [TARGETS[bundle_id]]
-      )
-    end
-  end
-
   desc "Build and upload to TestFlight (iOS + macOS)"
   lane :beta do
     setup_ci
 
     ios_profiles = fetch_profiles(platform: "ios")
-    apply_signing(profiles: ios_profiles)
     build_app(
+      xcargs: SIGNING_XCARGS,
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
       export_options: {
@@ -67,8 +51,8 @@ platform :ios do
     upload_to_testflight(skip_waiting_for_build_processing: true)
 
     macos_profiles = fetch_profiles(platform: "macos")
-    apply_signing(profiles: macos_profiles)
     build_mac_app(
+      xcargs: SIGNING_XCARGS,
       scheme: "SpeedReader",
       project: "SpeedReader/SpeedReader.xcodeproj",
       output_directory: "./build/macos",
@@ -90,8 +74,8 @@ platform :ios do
     setup_ci
 
     ios_profiles = fetch_profiles(platform: "ios")
-    apply_signing(profiles: ios_profiles)
     build_app(
+      xcargs: SIGNING_XCARGS,
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
       export_options: {
@@ -108,8 +92,8 @@ platform :ios do
     )
 
     macos_profiles = fetch_profiles(platform: "macos")
-    apply_signing(profiles: macos_profiles)
     build_mac_app(
+      xcargs: SIGNING_XCARGS,
       scheme: "SpeedReader",
       project: "SpeedReader/SpeedReader.xcodeproj",
       output_directory: "./build/macos",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,10 @@ default_platform(:ios)
 APP_BUNDLE_ID = "com.chriscantu.SpeedReader"
 EXTENSION_BUNDLE_ID = "com.chriscantu.SpeedReader.SpeedReaderExtension"
 XCODE_PROJECT = "SpeedReader/SpeedReader.xcodeproj"
+TARGET_NAMES = {
+  APP_BUNDLE_ID => "SpeedReader",
+  EXTENSION_BUNDLE_ID => "SpeedReaderExtension"
+}.freeze
 
 platform :ios do
   before_all do
@@ -30,49 +34,28 @@ platform :ios do
     profiles
   end
 
-  # Set platform-conditional signing in the Xcode project (CI checkout only).
-  # The project supports both iOS and macOS (SUPPORTED_PLATFORMS), so each
-  # target needs per-SDK profile specifiers to avoid cross-platform validation
-  # errors during archive.
-  private_lane :configure_signing do |options|
-    ios_profiles = options[:ios_profiles]
-    macos_profiles = options[:macos_profiles]
-
-    require "xcodeproj"
-    project = Xcodeproj::Project.open("../#{XCODE_PROJECT}")
-
-    target_bundle_ids = {
-      "SpeedReader" => APP_BUNDLE_ID,
-      "SpeedReaderExtension" => EXTENSION_BUNDLE_ID
-    }
-
-    project.targets.each do |target|
-      bundle_id = target_bundle_ids[target.name]
-      next unless bundle_id
-
-      target.build_configurations.each do |config|
-        s = config.build_settings
-        s["CODE_SIGN_STYLE"] = "Manual"
-        s["CODE_SIGN_IDENTITY"] = "Apple Distribution"
-        s["CODE_SIGN_IDENTITY[sdk=macosx*]"] = "Apple Distribution"
-        # Base value applies to iphoneos/iphonesimulator
-        s["PROVISIONING_PROFILE_SPECIFIER"] = ios_profiles[bundle_id]
-        # macOS override
-        s["PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]"] = macos_profiles[bundle_id]
-      end
+  # Switch Xcode project to manual signing with the given profiles.
+  # Called once per platform build on the disposable CI checkout.
+  private_lane :apply_signing do |options|
+    profiles = options[:profiles]
+    profiles.each do |bundle_id, profile_name|
+      update_code_signing_settings(
+        path: XCODE_PROJECT,
+        use_automatic_signing: false,
+        code_sign_identity: "Apple Distribution",
+        profile_name: profile_name,
+        targets: [TARGET_NAMES[bundle_id]]
+      )
     end
-
-    project.save
   end
 
   desc "Build and upload to TestFlight (iOS + macOS)"
   lane :beta do
     setup_ci
 
+    # --- iOS ---
     ios_profiles = fetch_profiles(platform: "ios")
-    macos_profiles = fetch_profiles(platform: "macos")
-    configure_signing(ios_profiles: ios_profiles, macos_profiles: macos_profiles)
-
+    apply_signing(profiles: ios_profiles)
     build_app(
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
@@ -83,7 +66,11 @@ platform :ios do
     )
     upload_to_testflight(skip_waiting_for_build_processing: true)
 
+    # --- macOS ---
+    macos_profiles = fetch_profiles(platform: "macos")
+    apply_signing(profiles: macos_profiles)
     build_mac_app(
+      destination: "generic/platform=macOS",
       scheme: "SpeedReader",
       project: XCODE_PROJECT,
       output_directory: "./build/macos",
@@ -104,10 +91,9 @@ platform :ios do
   lane :release do
     setup_ci
 
+    # --- iOS ---
     ios_profiles = fetch_profiles(platform: "ios")
-    macos_profiles = fetch_profiles(platform: "macos")
-    configure_signing(ios_profiles: ios_profiles, macos_profiles: macos_profiles)
-
+    apply_signing(profiles: ios_profiles)
     build_app(
       destination: "generic/platform=iOS",
       output_directory: "./build/ios",
@@ -124,7 +110,11 @@ platform :ios do
       precheck_include_in_app_purchases: false
     )
 
+    # --- macOS ---
+    macos_profiles = fetch_profiles(platform: "macos")
+    apply_signing(profiles: macos_profiles)
     build_mac_app(
+      destination: "generic/platform=macOS",
       scheme: "SpeedReader",
       project: XCODE_PROJECT,
       output_directory: "./build/macos",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,7 +39,7 @@ platform :ios do
     macos_profiles = options[:macos_profiles]
 
     require "xcodeproj"
-    project = Xcodeproj::Project.open(XCODE_PROJECT)
+    project = Xcodeproj::Project.open("../#{XCODE_PROJECT}")
 
     target_bundle_ids = {
       "SpeedReader" => APP_BUNDLE_ID,


### PR DESCRIPTION
## Summary

Fixes certificate exhaustion caused by `-allowProvisioningUpdates` auto-creating new distribution certificates on every CI run (Apple limits accounts to 3).

**Changes:**
- Remove `auth_xcargs` helper (which passed `-allowProvisioningUpdates` to xcodebuild)
- Use `sigh` (`get_provisioning_profile`) to manage provisioning profiles — sigh never creates certificates
- Use `update_code_signing_settings` to switch the Xcode project from automatic to manual signing on CI (disposable checkout only)
- Add explicit `destination: "generic/platform=macOS"` to `build_mac_app` for multi-platform project compatibility
- Bump version to 1.1.1 (build 10)

No changes to the deploy workflow files — the P12 certificate import is correct and unchanged.

Closes #55

## Test plan

- [x] Trigger TestFlight deploy — iOS build, export, and upload all succeed (build 36s, upload 44s)
- [x] Confirm no new distribution certificates created — zero cert creation activity in logs
- [x] macOS archive succeeds with manual signing + explicit destination (27s)
- [ ] **Blocked:** macOS export requires a "Mac Installer Distribution" certificate not present in `SIGNING_CERTIFICATE_P12` — needs infra fix (add Mac Installer cert to secrets). This is a pre-existing gap, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)